### PR TITLE
Feature: Add one-to-many relation between User and Clinic

### DIFF
--- a/src/main/java/com/medspace/application/service/ClinicService.java
+++ b/src/main/java/com/medspace/application/service/ClinicService.java
@@ -30,4 +30,8 @@ public class ClinicService {
     public List<Clinic> getAllClinics() {
         return clinicRepository.getAllClinics();
     }
+
+    public Clinic assignLandlord(Long clinicId, Long userId) {
+        return clinicRepository.assignClinicToUser(clinicId, userId);
+    }
 }

--- a/src/main/java/com/medspace/application/usecase/clinic/AssignClinicToUserUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinic/AssignClinicToUserUseCase.java
@@ -1,0 +1,16 @@
+package com.medspace.application.usecase.clinic;
+
+import com.medspace.application.service.ClinicService;
+import com.medspace.domain.model.Clinic;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class AssignClinicToUserUseCase {
+    @Inject
+    ClinicService clinicService;
+
+    public Clinic execute(Long clinicId, Long userId) {
+        return clinicService.assignLandlord(clinicId, userId);
+    }
+}

--- a/src/main/java/com/medspace/domain/model/Clinic.java
+++ b/src/main/java/com/medspace/domain/model/Clinic.java
@@ -37,5 +37,7 @@ public class Clinic {
     private String addressLongitude;
     private String addressLatitude;
 
+    private User landlord;
+
     private Instant createdAt;
 }

--- a/src/main/java/com/medspace/domain/repository/ClinicRepository.java
+++ b/src/main/java/com/medspace/domain/repository/ClinicRepository.java
@@ -9,4 +9,5 @@ public interface ClinicRepository {
     public List<Clinic> getAllClinics();
     public Clinic getClinicById(Long id);
     public void deleteClinicById(Long id);
+    public Clinic assignClinicToUser(Long clinicId, Long userId);
 }

--- a/src/main/java/com/medspace/infrastructure/dto/CreateClinicDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/CreateClinicDTO.java
@@ -46,6 +46,9 @@ public class CreateClinicDTO {
     @NotBlank
     private String addressLatitude;
 
+    @NotNull
+    private Long userId;
+
     public Clinic toClinic() {
         Clinic clinic = new Clinic();
 

--- a/src/main/java/com/medspace/infrastructure/entity/ClinicEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/ClinicEntity.java
@@ -20,40 +20,44 @@ public class ClinicEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "display_name")
+    @Column(name = "display_name", nullable = false)
     private String displayName;
 
-    @Column(name = "category")
+    @Column(name = "category", nullable = false)
     @Enumerated(EnumType.STRING)
     private Clinic.Category category;
 
-    @Column(name = "price_per_day")
+    @Column(name = "price_per_day", nullable = false)
     private double pricePerDay;
 
-    @Column(name = "max_stay_days")
+    @Column(name = "max_stay_days", nullable = false)
     private int maxStayDays;
 
-    @Column(name = "address_street")
+    @Column(name = "address_street", nullable = false)
     private String addressStreet;
 
-    @Column(name = "address_city")
+    @Column(name = "address_city", nullable = false)
     private String addressCity;
 
-    @Column(name = "address_state")
+    @Column(name = "address_state", nullable = false)
     private String addressState;
 
-    @Column(name = "address_zip")
+    @Column(name = "address_zip", nullable = false)
     private String addressZip;
 
-    @Column(name = "address_country")
+    @Column(name = "address_country", nullable = false)
     private String addressCountry;
 
-    @Column(name = "address_longitude")
+    @Column(name = "address_longitude", nullable = false)
     private String addressLongitude;
 
-    @Column(name = "address_latitude")
+    @Column(name = "address_latitude", nullable = false)
     private String addressLatitude;
 
-    @Column(name = "created_at")
+    @Column(name = "created_at", nullable = false)
     private Instant createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "landlord_id")
+    private UserEntity landlord;
 }

--- a/src/main/java/com/medspace/infrastructure/entity/UserEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/UserEntity.java
@@ -1,6 +1,8 @@
 package com.medspace.infrastructure.entity;
 
 import java.sql.Timestamp;
+import java.util.Set;
+
 import com.medspace.domain.model.User;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.persistence.*;
@@ -60,4 +62,6 @@ public class UserEntity extends PanacheEntityBase {
     @Column(name = "default_payment_method")
     private String defaultPaymentMethod;
 
+    @OneToMany(mappedBy = "landlord", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Set<ClinicEntity> clinics;
 }

--- a/src/main/java/com/medspace/infrastructure/mapper/ClinicMapper.java
+++ b/src/main/java/com/medspace/infrastructure/mapper/ClinicMapper.java
@@ -23,6 +23,8 @@ public class ClinicMapper {
         clinic.setAddressLongitude(clinicEntity.getAddressLongitude());
         clinic.setAddressLatitude(clinicEntity.getAddressLatitude());
 
+        clinic.setLandlord(UserMapper.toDomain(clinicEntity.getLandlord()));
+
         clinic.setCreatedAt(clinicEntity.getCreatedAt());
 
         return clinic;
@@ -45,6 +47,8 @@ public class ClinicMapper {
         clinicEntity.setAddressZip(clinic.getAddressZip());
         clinicEntity.setAddressLongitude(clinic.getAddressLongitude());
         clinicEntity.setAddressLatitude(clinic.getAddressLatitude());
+
+        clinicEntity.setLandlord(UserMapper.toEntity(clinic.getLandlord()));
 
         clinicEntity.setCreatedAt(clinic.getCreatedAt());
 

--- a/src/main/java/com/medspace/infrastructure/repository/ClinicRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/ClinicRepositoryImpl.java
@@ -3,9 +3,11 @@ package com.medspace.infrastructure.repository;
 import com.medspace.domain.model.Clinic;
 import com.medspace.domain.repository.ClinicRepository;
 import com.medspace.infrastructure.entity.ClinicEntity;
+import com.medspace.infrastructure.entity.UserEntity;
 import com.medspace.infrastructure.mapper.ClinicMapper;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.NotFoundException;
 
@@ -14,6 +16,9 @@ import java.util.List;
 
 @ApplicationScoped
 public class ClinicRepositoryImpl implements ClinicRepository, PanacheRepositoryBase<ClinicEntity, Long> {
+    @Inject
+    UserRepositoryImpl userRepository;
+
     @Override
     @Transactional
     public Clinic insertClinic(Clinic clinic) {
@@ -53,5 +58,23 @@ public class ClinicRepositoryImpl implements ClinicRepository, PanacheRepository
         } else {
             throw new NotFoundException("clinic with id " + id + " not found");
         }
+    }
+
+    @Override
+    @Transactional
+    public Clinic assignClinicToUser(Long clinicId, Long userId) {
+        ClinicEntity clinicEntity = findById(clinicId);
+        if(clinicEntity == null){
+            throw new NotFoundException("clinic with id " + clinicId + " not found");
+        }
+
+        UserEntity userEntity = userRepository.findById(userId);
+        if(userEntity == null){
+            throw new NotFoundException("user with id " + userId + " not found");
+        }
+
+        clinicEntity.setLandlord(userEntity);
+        persist(clinicEntity);
+        return ClinicMapper.toDomain(clinicEntity);
     }
 }

--- a/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
@@ -1,13 +1,11 @@
 package com.medspace.infrastructure.rest;
 
-import com.medspace.application.usecase.clinic.CreateClinicUseCase;
-import com.medspace.application.usecase.clinic.DeleteClinicByIdUseCase;
-import com.medspace.application.usecase.clinic.GetAllClinicsUseCase;
-import com.medspace.application.usecase.clinic.GetClinicByIdUseCase;
+import com.medspace.application.usecase.clinic.*;
 import com.medspace.domain.model.Clinic;
 import com.medspace.infrastructure.dto.CreateClinicDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -29,11 +27,16 @@ public class ClinicController {
     GetClinicByIdUseCase getClinicByIdUseCase;
     @Inject
     DeleteClinicByIdUseCase deleteClinicByIdUseCase;
+    @Inject
+    AssignClinicToUserUseCase assignClinicToUserUseCase;
 
     @POST
+    @Transactional
     public Response createClinic(@Valid CreateClinicDTO clinicRequest) {
         try {
             Clinic createdClinic = createClinicUseCase.execute(clinicRequest.toClinic());
+            createdClinic = assignClinicToUserUseCase.execute(createdClinic.getId(), clinicRequest.getUserId());
+
             return Response.status(Response.Status.CREATED)
                     .entity(createdClinic)
                     .build();


### PR DESCRIPTION
## Summary
This PR links the 'Clinic' entity to the 'User' entity via a one-to-many relation, following CLEAN architecture principles.

## Context
**Continuation of PR #2**

The model is implemented according to this [design](https://drawsql.app/teams/jose-luis-team/diagrams/medspace)
It is part of this Jira [task](https://paez-tec.atlassian.net/browse/MED-75?atlOrigin=eyJpIjoiYjI5MGZmMzJmNDFhNDY0ODlhYTk1YjFhMDcyYjViMzEiLCJwIjoiaiJ9)

## Changes
Changed entities to support one-to-many relation:
- `ClinicEntity`
- `UserEntity`

Implemented use case, with its corresponding services:
- `AssignClinicToUserUseCase`

Updated the `ClinicController` endpoints:
- `POST /clinics` - Create a Clinic now accepts a userId param as part of the DTO

## Test Plan
Manually tested the new endpoints using Insomnia. Confirmed that responses matched expected status code and that persistence in db works fine.

**POST /clinics**
Sample request:
`{
	"displayName": "consultorio médico",
	"category": "GENERAL_USE",
	"pricePerDay": 120.0,
	"maxStayDays": 10,
	"addressStreet": "Av hacker",
	"addressCity": "CDMX",
	"addressState": "Ciudad de Mexico",
	"addressZip": "123",
	"addressCountry": "Mexico",
	"addressLongitude": "134.234",
	"addressLatitude": "1234.23",
	"userId": 1
}`

<img width="1034" alt="Captura de pantalla 2025-04-17 a la(s) 6 31 51 p m" src="https://github.com/user-attachments/assets/581bc1bd-46d9-48d9-9719-5bf88f057c67" />
