### PR TITLE
Refactor: Implement ResponseDTO in ClinicController

### DIFF
--- a/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
@@ -3,6 +3,7 @@ package com.medspace.infrastructure.rest;
 import com.medspace.application.usecase.clinic.*;
 import com.medspace.domain.model.Clinic;
 import com.medspace.infrastructure.dto.CreateClinicDTO;
+import com.medspace.infrastructure.dto.ResponseDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -35,14 +36,14 @@ public class ClinicController {
     public Response createClinic(@Valid CreateClinicDTO clinicRequest) {
         try {
             Clinic createdClinic = createClinicUseCase.execute(clinicRequest.toClinic());
-            createdClinic = assignClinicToUserUseCase.execute(createdClinic.getId(), clinicRequest.getUserId());
+            assignClinicToUserUseCase.execute(createdClinic.getId(), clinicRequest.getUserId());
 
             return Response.status(Response.Status.CREATED)
-                    .entity(createdClinic)
+                    .entity(ResponseDTO.success("Clinic Created"))
                     .build();
         } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(Map.of("error", e.getMessage()))
+                    .entity(ResponseDTO.error(e.getMessage()))
                     .build();
         }
     }
@@ -51,10 +52,12 @@ public class ClinicController {
     public Response getAllClinics() {
         try {
             List<Clinic> clinics = getAllClinicsUseCase.execute();
-            return Response.ok(clinics).build();
+            return Response
+                    .ok(ResponseDTO.success("Clinics Fetched", clinics))
+                    .build();
         } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(Map.of("error", e.getMessage()))
+                    .entity(ResponseDTO.error(e.getMessage()))
                     .build();
         }
     }
@@ -66,13 +69,15 @@ public class ClinicController {
             Clinic clinic = getClinicByIdUseCase.execute(id);
             if (clinic == null) {
                 return Response.status(Response.Status.NOT_FOUND)
-                        .entity(Map.of("error", "clinic not found"))
+                        .entity(ResponseDTO.error("Clinic not Found"))
                         .build();
             }
-            return Response.ok(clinic).build();
+            return Response
+                    .ok(ResponseDTO.success("Clinic Fetched", clinic))
+                    .build();
         } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(Map.of("error", e.getMessage()))
+                    .entity(ResponseDTO.error(e.getMessage()))
                     .build();
         }
     }
@@ -82,14 +87,16 @@ public class ClinicController {
     public Response deleteClinicById(@PathParam("id") Long id) {
         try {
             deleteClinicByIdUseCase.execute(id);
-            return Response.status(Response.Status.NO_CONTENT).build();
+            return Response
+                    .ok(ResponseDTO.success("Clinic Deleted"))
+                    .build();
         } catch (NotFoundException e) {
             return Response.status(Response.Status.NOT_FOUND)
-                    .entity(Map.of("error", e.getMessage()))
+                    .entity(ResponseDTO.error(e.getMessage()))
                     .build();
         } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(Map.of("error", e.getMessage()))
+                    .entity(ResponseDTO.error(e.getMessage()))
                     .build();
         }
     }


### PR DESCRIPTION
## Summary
This PR uses the newly created `ResponseDTO` to standardize the returned http Response object in the `ClinicController` endpoints.

## Context
Implements the `ResponseDTO` created in PR #4 

## Changes
ClinicController:
- Change all `Response.entity` to return a ResponseDTO with appropriate data

## Test Plan
Tested manually the four ClinicController endpoints to confirm that the returned JSON has correct format:

**POST /clinics**
<img width="796" alt="Captura de pantalla 2025-04-18 a la(s) 10 27 26 a m" src="https://github.com/user-attachments/assets/ac23a593-4610-4861-b9ac-738fe34d6c83" />

**GET /clinics**
<img width="944" alt="Captura de pantalla 2025-04-18 a la(s) 10 27 51 a m" src="https://github.com/user-attachments/assets/02e58ba7-d82b-49b9-ba52-e5f0a5851921" />

**GET /clinics/{id}**
<img width="964" alt="Captura de pantalla 2025-04-18 a la(s) 10 28 10 a m" src="https://github.com/user-attachments/assets/59a0dc12-7d44-4418-bf5e-dd97a1e9b587" />

**DELETE /clinics/{id}**
<img width="832" alt="Captura de pantalla 2025-04-18 a la(s) 10 28 45 a m" src="https://github.com/user-attachments/assets/1b258934-8c86-470e-8cd4-69ae3b07b051" />


