### PR TITLE
Feature: Add ClinicPhoto model

### DIFF
--- a/src/main/java/com/medspace/application/service/ClinicPhotoService.java
+++ b/src/main/java/com/medspace/application/service/ClinicPhotoService.java
@@ -1,0 +1,41 @@
+package com.medspace.application.service;
+
+import com.medspace.application.service.external.FileStorageService;
+import com.medspace.domain.model.ClinicPhoto;
+import com.medspace.domain.repository.ClinicPhotoRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.List;
+
+@ApplicationScoped
+public class ClinicPhotoService {
+    @Inject
+    ClinicPhotoRepository clinicPhotoRepository;
+    @Inject
+    FileStorageService fileStorageService;
+
+    public ClinicPhoto createPhoto(ClinicPhoto clinicPhoto, InputStream photoInputStream) {
+        clinicPhoto.setCreatedAt(Instant.now());
+        String savedUrl = fileStorageService.saveFile(photoInputStream);
+        clinicPhoto.setUrl(savedUrl);
+
+        clinicPhoto = clinicPhotoRepository.insertPhoto(clinicPhoto);
+
+        return clinicPhoto;
+    }
+
+    public ClinicPhoto assignPhotoToClinic(Long clinicPhotoId, Long clinicId) {
+        return clinicPhotoRepository.assignPhotoToClinic(clinicPhotoId, clinicId);
+    }
+
+    public List<ClinicPhoto> listPhotosByClinicId(Long clinicId) {
+        return clinicPhotoRepository.getClinicPhotosByClinicId(clinicId);
+    }
+
+    public void deletePhoto(Long id) {
+        clinicPhotoRepository.deletePhotoById(id);
+    }
+}

--- a/src/main/java/com/medspace/application/service/ClinicPhotoService.java
+++ b/src/main/java/com/medspace/application/service/ClinicPhotoService.java
@@ -38,4 +38,12 @@ public class ClinicPhotoService {
     public void deletePhoto(Long id) {
         clinicPhotoRepository.deletePhotoById(id);
     }
+
+    public ClinicPhoto getPhotoById(Long id) {
+        return clinicPhotoRepository.getPhotoById(id);
+    }
+
+    public void setPhotoAsPrimary(Long id) {
+        clinicPhotoRepository.setPhotoAsPrimary(id);
+    }
 }

--- a/src/main/java/com/medspace/application/service/external/FileStorageService.java
+++ b/src/main/java/com/medspace/application/service/external/FileStorageService.java
@@ -1,0 +1,7 @@
+package com.medspace.application.service.external;
+
+import java.io.InputStream;
+
+public interface FileStorageService {
+    public String saveFile(InputStream inputStream);
+}

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/AssignPhotoToClinicUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/AssignPhotoToClinicUseCase.java
@@ -1,0 +1,16 @@
+package com.medspace.application.usecase.clinicPhoto;
+
+import com.medspace.application.service.ClinicPhotoService;
+import com.medspace.domain.model.ClinicPhoto;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class AssignPhotoToClinicUseCase {
+    @Inject
+    ClinicPhotoService clinicPhotoService;
+
+    public ClinicPhoto execute(Long clinicPhotoId, Long clinicId) {
+        return clinicPhotoService.assignPhotoToClinic(clinicPhotoId, clinicId);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/CreateClinicPhotoUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/CreateClinicPhotoUseCase.java
@@ -1,0 +1,18 @@
+package com.medspace.application.usecase.clinicPhoto;
+
+import com.medspace.application.service.ClinicPhotoService;
+import com.medspace.domain.model.ClinicPhoto;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.io.InputStream;
+
+@ApplicationScoped
+public class CreateClinicPhotoUseCase {
+    @Inject
+    ClinicPhotoService clinicPhotoService;
+
+    public ClinicPhoto execute(ClinicPhoto clinicPhoto, InputStream photoInputStream) {
+        return clinicPhotoService.createPhoto(clinicPhoto, photoInputStream);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/DeleteClinicPhotoByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/DeleteClinicPhotoByIdUseCase.java
@@ -1,0 +1,15 @@
+package com.medspace.application.usecase.clinicPhoto;
+
+import com.medspace.application.service.ClinicPhotoService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class DeleteClinicPhotoByIdUseCase {
+    @Inject
+    ClinicPhotoService clinicPhotoService;
+
+    public void execute(Long id) {
+        clinicPhotoService.deletePhoto(id);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/GetClinicPhotoByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/GetClinicPhotoByIdUseCase.java
@@ -1,0 +1,18 @@
+package com.medspace.application.usecase.clinicPhoto;
+
+import com.medspace.application.service.ClinicPhotoService;
+import com.medspace.domain.model.ClinicPhoto;
+import com.medspace.infrastructure.dto.GetClinicPhotoDTO;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class GetClinicPhotoByIdUseCase {
+    @Inject
+    ClinicPhotoService clinicPhotoService;
+
+    public GetClinicPhotoDTO execute(Long id) {
+        ClinicPhoto clinicPhoto = clinicPhotoService.getPhotoById(id);
+        return new GetClinicPhotoDTO(clinicPhoto);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/GetPhotosByClinicIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/GetPhotosByClinicIdUseCase.java
@@ -2,7 +2,7 @@ package com.medspace.application.usecase.clinicPhoto;
 
 import com.medspace.application.service.ClinicPhotoService;
 import com.medspace.domain.model.ClinicPhoto;
-import com.medspace.infrastructure.dto.GetPhotoByClinicIdDTO;
+import com.medspace.infrastructure.dto.GetClinicPhotoDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -14,12 +14,12 @@ public class GetPhotosByClinicIdUseCase {
     @Inject
     ClinicPhotoService clinicPhotoService;
 
-    public List<GetPhotoByClinicIdDTO> execute(Long clinicId) {
+    public List<GetClinicPhotoDTO> execute(Long clinicId) {
         List<ClinicPhoto> clinicPhotos = clinicPhotoService.listPhotosByClinicId(clinicId);
-        List<GetPhotoByClinicIdDTO> clinicPhotoDTOs = new ArrayList<>();
+        List<GetClinicPhotoDTO> clinicPhotoDTOs = new ArrayList<>();
 
         for (ClinicPhoto clinicPhoto : clinicPhotos) {
-            clinicPhotoDTOs.add(new GetPhotoByClinicIdDTO(clinicPhoto));
+            clinicPhotoDTOs.add(new GetClinicPhotoDTO(clinicPhoto));
         }
 
         return clinicPhotoDTOs;

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/GetPhotosByClinicIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/GetPhotosByClinicIdUseCase.java
@@ -1,0 +1,27 @@
+package com.medspace.application.usecase.clinicPhoto;
+
+import com.medspace.application.service.ClinicPhotoService;
+import com.medspace.domain.model.ClinicPhoto;
+import com.medspace.infrastructure.dto.GetPhotoByClinicIdDTO;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ApplicationScoped
+public class GetPhotosByClinicIdUseCase {
+    @Inject
+    ClinicPhotoService clinicPhotoService;
+
+    public List<GetPhotoByClinicIdDTO> execute(Long clinicId) {
+        List<ClinicPhoto> clinicPhotos = clinicPhotoService.listPhotosByClinicId(clinicId);
+        List<GetPhotoByClinicIdDTO> clinicPhotoDTOs = new ArrayList<>();
+
+        for (ClinicPhoto clinicPhoto : clinicPhotos) {
+            clinicPhotoDTOs.add(new GetPhotoByClinicIdDTO(clinicPhoto));
+        }
+
+        return clinicPhotoDTOs;
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/SetPhotoAsPrimaryClinicPhotoUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/SetPhotoAsPrimaryClinicPhotoUseCase.java
@@ -1,0 +1,15 @@
+package com.medspace.application.usecase.clinicPhoto;
+
+import com.medspace.application.service.ClinicPhotoService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class SetPhotoAsPrimaryClinicPhotoUseCase {
+    @Inject
+    ClinicPhotoService clinicPhotoService;
+
+    public void execute(Long id) {
+        clinicPhotoService.setPhotoAsPrimary(id);
+    }
+}

--- a/src/main/java/com/medspace/domain/model/ClinicPhoto.java
+++ b/src/main/java/com/medspace/domain/model/ClinicPhoto.java
@@ -1,0 +1,21 @@
+package com.medspace.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+public class ClinicPhoto {
+    private Long id;
+    private String url;
+
+    private Clinic clinic;
+
+    private Instant createdAt;
+}

--- a/src/main/java/com/medspace/domain/model/ClinicPhoto.java
+++ b/src/main/java/com/medspace/domain/model/ClinicPhoto.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 public class ClinicPhoto {
     private Long id;
     private String url;
+    private Boolean isPrimary;
 
     private Clinic clinic;
 

--- a/src/main/java/com/medspace/domain/repository/ClinicPhotoRepository.java
+++ b/src/main/java/com/medspace/domain/repository/ClinicPhotoRepository.java
@@ -1,0 +1,13 @@
+package com.medspace.domain.repository;
+
+import com.medspace.domain.model.ClinicPhoto;
+
+import java.util.List;
+
+public interface ClinicPhotoRepository {
+    public ClinicPhoto insertPhoto(ClinicPhoto clinicPhoto);
+    public ClinicPhoto getPhotoById(Long id);
+    public void deletePhotoById(Long id);
+    public ClinicPhoto assignPhotoToClinic(Long clinicPhotoId, Long clinicId);
+    public List<ClinicPhoto> getClinicPhotosByClinicId(Long clinicId);
+}

--- a/src/main/java/com/medspace/domain/repository/ClinicPhotoRepository.java
+++ b/src/main/java/com/medspace/domain/repository/ClinicPhotoRepository.java
@@ -10,4 +10,5 @@ public interface ClinicPhotoRepository {
     public void deletePhotoById(Long id);
     public ClinicPhoto assignPhotoToClinic(Long clinicPhotoId, Long clinicId);
     public List<ClinicPhoto> getClinicPhotosByClinicId(Long clinicId);
+    public void setPhotoAsPrimary(Long id);
 }

--- a/src/main/java/com/medspace/infrastructure/dto/CreateClinicPhotoDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/CreateClinicPhotoDTO.java
@@ -1,0 +1,33 @@
+package com.medspace.infrastructure.dto;
+
+import com.medspace.domain.model.ClinicPhoto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.core.MediaType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.jboss.resteasy.annotations.providers.multipart.PartType;
+
+import java.io.InputStream;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateClinicPhotoDTO {
+    @FormParam("clinicId")
+    @PartType(MediaType.TEXT_PLAIN)
+    @NotNull
+    private Long clinicId;
+
+    @FormParam("photo")
+    @PartType(MediaType.APPLICATION_OCTET_STREAM)
+    private InputStream photo;
+
+    public ClinicPhoto toClinicPhoto() {
+        return new ClinicPhoto();
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/dto/CreateClinicPhotoDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/CreateClinicPhotoDTO.java
@@ -23,11 +23,18 @@ public class CreateClinicPhotoDTO {
     @NotNull
     private Long clinicId;
 
+    @FormParam("isPrimary")
+    @PartType(MediaType.TEXT_PLAIN)
+    @NotNull
+    private Boolean isPrimary;
+
     @FormParam("photo")
     @PartType(MediaType.APPLICATION_OCTET_STREAM)
     private InputStream photo;
 
     public ClinicPhoto toClinicPhoto() {
-        return new ClinicPhoto();
+        ClinicPhoto clinicPhoto = new ClinicPhoto();
+        clinicPhoto.setIsPrimary(isPrimary);
+        return clinicPhoto;
     }
 }

--- a/src/main/java/com/medspace/infrastructure/dto/GetClinicPhotoDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/GetClinicPhotoDTO.java
@@ -10,12 +10,12 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class GetPhotoByClinicIdDTO {
+public class GetClinicPhotoDTO {
     private Long id;
     private Long clinicId;
     private String url;
 
-    public GetPhotoByClinicIdDTO(ClinicPhoto clinicPhoto) {
+    public GetClinicPhotoDTO(ClinicPhoto clinicPhoto) {
         this.id = clinicPhoto.getId();
         this.clinicId = clinicPhoto.getClinic().getId();
         this.url = clinicPhoto.getUrl();

--- a/src/main/java/com/medspace/infrastructure/dto/GetPhotoByClinicIdDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/GetPhotoByClinicIdDTO.java
@@ -1,0 +1,23 @@
+package com.medspace.infrastructure.dto;
+
+import com.medspace.domain.model.ClinicPhoto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetPhotoByClinicIdDTO {
+    private Long id;
+    private Long clinicId;
+    private String url;
+
+    public GetPhotoByClinicIdDTO(ClinicPhoto clinicPhoto) {
+        this.id = clinicPhoto.getId();
+        this.clinicId = clinicPhoto.getClinic().getId();
+        this.url = clinicPhoto.getUrl();
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/dto/SetPhotoAsPrimaryDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/SetPhotoAsPrimaryDTO.java
@@ -1,0 +1,16 @@
+package com.medspace.infrastructure.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SetPhotoAsPrimaryDTO {
+    @NotNull
+    private Long photoId;
+}

--- a/src/main/java/com/medspace/infrastructure/entity/ClinicEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/ClinicEntity.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.Instant;
+import java.util.Set;
 
 @Entity
 @Table(name = "clinics")
@@ -60,4 +61,7 @@ public class ClinicEntity {
     @ManyToOne
     @JoinColumn(name = "landlord_id")
     private UserEntity landlord;
+
+    @OneToMany(mappedBy = "clinic", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Set<ClinicPhotoEntity> photos;
 }

--- a/src/main/java/com/medspace/infrastructure/entity/ClinicPhotoEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/ClinicPhotoEntity.java
@@ -1,0 +1,31 @@
+package com.medspace.infrastructure.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "clinic_photos")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClinicPhotoEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "url", nullable = false)
+    private String url;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "clinic_id")
+    private ClinicEntity clinic;
+}

--- a/src/main/java/com/medspace/infrastructure/entity/ClinicPhotoEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/ClinicPhotoEntity.java
@@ -22,6 +22,9 @@ public class ClinicPhotoEntity {
     @Column(name = "url", nullable = false)
     private String url;
 
+    @Column(name = "is_primary", nullable = false)
+    private Boolean isPrimary = false;
+
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 

--- a/src/main/java/com/medspace/infrastructure/mapper/ClinicMapper.java
+++ b/src/main/java/com/medspace/infrastructure/mapper/ClinicMapper.java
@@ -6,6 +6,10 @@ import com.medspace.infrastructure.entity.ClinicEntity;
 public class ClinicMapper {
 
     public static Clinic toDomain(ClinicEntity clinicEntity) {
+        if (clinicEntity == null) {
+            return null;
+        }
+
         Clinic clinic = new Clinic();
 
         clinic.setId(clinicEntity.getId());
@@ -31,6 +35,10 @@ public class ClinicMapper {
     }
 
     public static ClinicEntity toEntity(Clinic clinic) {
+        if (clinic == null) {
+            return null;
+        }
+
         ClinicEntity clinicEntity = new ClinicEntity();
 
         clinicEntity.setId(clinic.getId());

--- a/src/main/java/com/medspace/infrastructure/mapper/ClinicPhotoMapper.java
+++ b/src/main/java/com/medspace/infrastructure/mapper/ClinicPhotoMapper.java
@@ -12,6 +12,7 @@ public class ClinicPhotoMapper {
         ClinicPhoto clinicPhoto = new ClinicPhoto();
         clinicPhoto.setId(clinicPhotoEntity.getId());
         clinicPhoto.setUrl(clinicPhotoEntity.getUrl());
+        clinicPhoto.setIsPrimary(clinicPhotoEntity.getIsPrimary());
 
         clinicPhoto.setClinic(ClinicMapper.toDomain(clinicPhotoEntity.getClinic()));
 
@@ -28,6 +29,7 @@ public class ClinicPhotoMapper {
         ClinicPhotoEntity clinicPhotoEntity = new ClinicPhotoEntity();
         clinicPhotoEntity.setId(clinicPhoto.getId());
         clinicPhotoEntity.setUrl(clinicPhoto.getUrl());
+        clinicPhotoEntity.setIsPrimary(clinicPhoto.getIsPrimary());
 
         clinicPhotoEntity.setClinic(ClinicMapper.toEntity(clinicPhoto.getClinic()));
 

--- a/src/main/java/com/medspace/infrastructure/mapper/ClinicPhotoMapper.java
+++ b/src/main/java/com/medspace/infrastructure/mapper/ClinicPhotoMapper.java
@@ -5,6 +5,10 @@ import com.medspace.infrastructure.entity.ClinicPhotoEntity;
 
 public class ClinicPhotoMapper {
     public static ClinicPhoto toDomain(ClinicPhotoEntity clinicPhotoEntity) {
+        if (clinicPhotoEntity == null) {
+            return null;
+        }
+
         ClinicPhoto clinicPhoto = new ClinicPhoto();
         clinicPhoto.setId(clinicPhotoEntity.getId());
         clinicPhoto.setUrl(clinicPhotoEntity.getUrl());
@@ -17,6 +21,10 @@ public class ClinicPhotoMapper {
     }
 
     public static ClinicPhotoEntity toEntity(ClinicPhoto clinicPhoto) {
+        if (clinicPhoto == null) {
+            return null;
+        }
+
         ClinicPhotoEntity clinicPhotoEntity = new ClinicPhotoEntity();
         clinicPhotoEntity.setId(clinicPhoto.getId());
         clinicPhotoEntity.setUrl(clinicPhoto.getUrl());

--- a/src/main/java/com/medspace/infrastructure/mapper/ClinicPhotoMapper.java
+++ b/src/main/java/com/medspace/infrastructure/mapper/ClinicPhotoMapper.java
@@ -1,0 +1,30 @@
+package com.medspace.infrastructure.mapper;
+
+import com.medspace.domain.model.ClinicPhoto;
+import com.medspace.infrastructure.entity.ClinicPhotoEntity;
+
+public class ClinicPhotoMapper {
+    public static ClinicPhoto toDomain(ClinicPhotoEntity clinicPhotoEntity) {
+        ClinicPhoto clinicPhoto = new ClinicPhoto();
+        clinicPhoto.setId(clinicPhotoEntity.getId());
+        clinicPhoto.setUrl(clinicPhotoEntity.getUrl());
+
+        clinicPhoto.setClinic(ClinicMapper.toDomain(clinicPhotoEntity.getClinic()));
+
+        clinicPhoto.setCreatedAt(clinicPhotoEntity.getCreatedAt());
+
+        return clinicPhoto;
+    }
+
+    public static ClinicPhotoEntity toEntity(ClinicPhoto clinicPhoto) {
+        ClinicPhotoEntity clinicPhotoEntity = new ClinicPhotoEntity();
+        clinicPhotoEntity.setId(clinicPhoto.getId());
+        clinicPhotoEntity.setUrl(clinicPhoto.getUrl());
+
+        clinicPhotoEntity.setClinic(ClinicMapper.toEntity(clinicPhoto.getClinic()));
+
+        clinicPhotoEntity.setCreatedAt(clinicPhoto.getCreatedAt());
+
+        return clinicPhotoEntity;
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/repository/ClinicPhotoRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/ClinicPhotoRepositoryImpl.java
@@ -1,0 +1,82 @@
+package com.medspace.infrastructure.repository;
+
+import com.medspace.domain.model.ClinicPhoto;
+import com.medspace.domain.repository.ClinicPhotoRepository;
+import com.medspace.infrastructure.entity.ClinicEntity;
+import com.medspace.infrastructure.entity.ClinicPhotoEntity;
+import com.medspace.infrastructure.mapper.ClinicPhotoMapper;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.NotFoundException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ApplicationScoped
+public class ClinicPhotoRepositoryImpl implements ClinicPhotoRepository, PanacheRepositoryBase<ClinicPhotoEntity, Long> {
+    @Inject
+    ClinicRepositoryImpl clinicRepository;
+
+    @Transactional
+    @Override
+    public ClinicPhoto insertPhoto(ClinicPhoto clinicPhoto) {
+        ClinicPhotoEntity clinicPhotoEntity = ClinicPhotoMapper.toEntity(clinicPhoto);
+        persist(clinicPhotoEntity);
+        clinicPhoto = ClinicPhotoMapper.toDomain(clinicPhotoEntity);
+        return clinicPhoto;
+    }
+
+    @Override
+    public ClinicPhoto getPhotoById(Long id) {
+        ClinicPhotoEntity clinicPhotoEntity = findById(id);
+        if (clinicPhotoEntity == null) {
+            throw new NotFoundException("ClinicPhoto with id " + id + " not Found");
+        }
+        return ClinicPhotoMapper.toDomain(clinicPhotoEntity);
+    }
+
+    @Override
+    @Transactional
+    public void deletePhotoById(Long id) {
+        ClinicPhotoEntity clinicPhotoEntity = findById(id);
+        if (clinicPhotoEntity != null) {
+            delete(clinicPhotoEntity);
+        } else {
+            throw new NotFoundException("ClinicPhoto with id " + id + " not Found");
+        }
+    }
+
+    @Override
+    @Transactional
+    public ClinicPhoto assignPhotoToClinic(Long clinicPhotoId, Long clinicId) {
+        ClinicPhotoEntity clinicPhotoEntity = findById(clinicPhotoId);
+        if (clinicPhotoEntity == null) {
+            throw new NotFoundException("ClinicPhoto with id " + clinicPhotoId + " not Found");
+        }
+
+        ClinicEntity clinicEntity = clinicRepository.findById(clinicId);
+        if (clinicEntity == null) {
+            throw new NotFoundException("Clinic with id " + clinicId + " not Found");
+        }
+
+        clinicPhotoEntity.setClinic(clinicEntity);
+        persist(clinicPhotoEntity);
+        return ClinicPhotoMapper.toDomain(clinicPhotoEntity);
+    }
+
+    public List<ClinicPhoto> getClinicPhotosByClinicId(Long clinicId) {
+        ClinicEntity clinicEntity = clinicRepository.findById(clinicId);
+        if (clinicEntity == null) {
+            throw new NotFoundException("Clinic with id " + clinicId + " not Found");
+        }
+
+        List<ClinicPhoto> clinicPhotos = new ArrayList<>();
+        for(ClinicPhotoEntity clinicPhotoEntity : clinicEntity.getPhotos()) {
+            clinicPhotos.add(ClinicPhotoMapper.toDomain(clinicPhotoEntity));
+        }
+
+        return clinicPhotos;
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
@@ -1,8 +1,10 @@
 package com.medspace.infrastructure.rest;
 
 import com.medspace.application.usecase.clinic.*;
+import com.medspace.application.usecase.clinicPhoto.GetPhotosByClinicIdUseCase;
 import com.medspace.domain.model.Clinic;
 import com.medspace.infrastructure.dto.CreateClinicDTO;
+import com.medspace.infrastructure.dto.GetPhotoByClinicIdDTO;
 import com.medspace.infrastructure.dto.ResponseDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -13,10 +15,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import java.util.List;
-import java.util.Map;
 
 @ApplicationScoped
-@Path("clinics")
+@Path("/clinics")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class ClinicController {
@@ -30,6 +31,8 @@ public class ClinicController {
     DeleteClinicByIdUseCase deleteClinicByIdUseCase;
     @Inject
     AssignClinicToUserUseCase assignClinicToUserUseCase;
+    @Inject
+    GetPhotosByClinicIdUseCase getPhotosByClinicIdUseCase;
 
     @POST
     @Transactional
@@ -93,6 +96,22 @@ public class ClinicController {
         } catch (NotFoundException e) {
             return Response.status(Response.Status.NOT_FOUND)
                     .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        }
+    }
+
+    @GET
+    @Path("/{id}/photos")
+    public Response getPhotosByClinicId(@PathParam("id") Long id) {
+        try {
+            List<GetPhotoByClinicIdDTO> clinicPhotos = getPhotosByClinicIdUseCase.execute(id);
+
+            return Response
+                    .ok(ResponseDTO.success("ClinicPhoto Fetched", clinicPhotos))
                     .build();
         } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
@@ -1,11 +1,14 @@
 package com.medspace.infrastructure.rest;
 
 import com.medspace.application.usecase.clinic.*;
+import com.medspace.application.usecase.clinicPhoto.GetClinicPhotoByIdUseCase;
 import com.medspace.application.usecase.clinicPhoto.GetPhotosByClinicIdUseCase;
+import com.medspace.application.usecase.clinicPhoto.SetPhotoAsPrimaryClinicPhotoUseCase;
 import com.medspace.domain.model.Clinic;
 import com.medspace.infrastructure.dto.CreateClinicDTO;
-import com.medspace.infrastructure.dto.GetPhotoByClinicIdDTO;
+import com.medspace.infrastructure.dto.GetClinicPhotoDTO;
 import com.medspace.infrastructure.dto.ResponseDTO;
+import com.medspace.infrastructure.dto.SetPhotoAsPrimaryDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -15,6 +18,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import java.util.List;
+import java.util.Objects;
 
 @ApplicationScoped
 @Path("/clinics")
@@ -33,6 +37,10 @@ public class ClinicController {
     AssignClinicToUserUseCase assignClinicToUserUseCase;
     @Inject
     GetPhotosByClinicIdUseCase getPhotosByClinicIdUseCase;
+    @Inject
+    SetPhotoAsPrimaryClinicPhotoUseCase setPhotoAsPrimaryClinicPhotoUseCase;
+    @Inject
+    GetClinicPhotoByIdUseCase getClinicPhotoByIdUseCase;
 
     @POST
     @Transactional
@@ -108,10 +116,30 @@ public class ClinicController {
     @Path("/{id}/photos")
     public Response getPhotosByClinicId(@PathParam("id") Long id) {
         try {
-            List<GetPhotoByClinicIdDTO> clinicPhotos = getPhotosByClinicIdUseCase.execute(id);
+            List<GetClinicPhotoDTO> clinicPhotos = getPhotosByClinicIdUseCase.execute(id);
 
             return Response
                     .ok(ResponseDTO.success("ClinicPhoto Fetched", clinicPhotos))
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        }
+    }
+
+    @PUT
+    @Path("/{id}/primary-photo")
+    public Response setPrimaryPhoto(@PathParam("id") Long id, @Valid SetPhotoAsPrimaryDTO request) {
+        try {
+            GetClinicPhotoDTO clinicPhotoDTO = getClinicPhotoByIdUseCase.execute(request.getPhotoId());
+            if(!Objects.equals(clinicPhotoDTO.getClinicId(), id)) {
+                throw new Exception("Photo does not belong to Clinic");
+            }
+            setPhotoAsPrimaryClinicPhotoUseCase.execute(request.getPhotoId());
+
+            return Response
+                    .ok(ResponseDTO.success("Clinic Photo Updated"))
                     .build();
         } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/medspace/infrastructure/rest/ClinicPhotoController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/ClinicPhotoController.java
@@ -3,6 +3,7 @@ package com.medspace.infrastructure.rest;
 import com.medspace.application.usecase.clinicPhoto.AssignPhotoToClinicUseCase;
 import com.medspace.application.usecase.clinicPhoto.CreateClinicPhotoUseCase;
 import com.medspace.application.usecase.clinicPhoto.DeleteClinicPhotoByIdUseCase;
+import com.medspace.application.usecase.clinicPhoto.SetPhotoAsPrimaryClinicPhotoUseCase;
 import com.medspace.domain.model.ClinicPhoto;
 import com.medspace.infrastructure.dto.CreateClinicPhotoDTO;
 import com.medspace.infrastructure.dto.ResponseDTO;
@@ -26,6 +27,8 @@ public class ClinicPhotoController {
     AssignPhotoToClinicUseCase assignPhotoToClinicUseCase;
     @Inject
     DeleteClinicPhotoByIdUseCase deleteClinicPhotoByIdUseCase;
+    @Inject
+    SetPhotoAsPrimaryClinicPhotoUseCase setPhotoAsPrimaryClinicPhotoUseCase;
 
     @POST
     @Transactional
@@ -35,6 +38,10 @@ public class ClinicPhotoController {
             ClinicPhoto clinicPhoto = createClinicPhotoUseCase
                     .execute(photoRequest.toClinicPhoto(), photoRequest.getPhoto());
             assignPhotoToClinicUseCase.execute(clinicPhoto.getId(), photoRequest.getClinicId());
+
+            if(photoRequest.getIsPrimary()) {
+                setPhotoAsPrimaryClinicPhotoUseCase.execute(clinicPhoto.getId());
+            }
 
             return Response.status(Response.Status.CREATED)
                     .entity(ResponseDTO.success("ClinicPhoto Created"))
@@ -48,7 +55,7 @@ public class ClinicPhotoController {
 
     @DELETE
     @Path("/{id}")
-    public Response deleteClinicById(@PathParam("id") Long id) {
+    public Response deleteClinicPhotoById(@PathParam("id") Long id) {
         try {
             deleteClinicPhotoByIdUseCase.execute(id);
             return Response

--- a/src/main/java/com/medspace/infrastructure/rest/ClinicPhotoController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/ClinicPhotoController.java
@@ -1,0 +1,67 @@
+package com.medspace.infrastructure.rest;
+
+import com.medspace.application.usecase.clinicPhoto.AssignPhotoToClinicUseCase;
+import com.medspace.application.usecase.clinicPhoto.CreateClinicPhotoUseCase;
+import com.medspace.application.usecase.clinicPhoto.DeleteClinicPhotoByIdUseCase;
+import com.medspace.domain.model.ClinicPhoto;
+import com.medspace.infrastructure.dto.CreateClinicPhotoDTO;
+import com.medspace.infrastructure.dto.ResponseDTO;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
+
+@ApplicationScoped
+@Path("/clinic-photos")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class ClinicPhotoController {
+    @Inject
+    CreateClinicPhotoUseCase createClinicPhotoUseCase;
+    @Inject
+    AssignPhotoToClinicUseCase assignPhotoToClinicUseCase;
+    @Inject
+    DeleteClinicPhotoByIdUseCase deleteClinicPhotoByIdUseCase;
+
+    @POST
+    @Transactional
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public Response createClinicPhoto(@MultipartForm @Valid CreateClinicPhotoDTO photoRequest) {
+        try {
+            ClinicPhoto clinicPhoto = createClinicPhotoUseCase
+                    .execute(photoRequest.toClinicPhoto(), photoRequest.getPhoto());
+            assignPhotoToClinicUseCase.execute(clinicPhoto.getId(), photoRequest.getClinicId());
+
+            return Response.status(Response.Status.CREATED)
+                    .entity(ResponseDTO.success("ClinicPhoto Created"))
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        }
+    }
+
+    @DELETE
+    @Path("/{id}")
+    public Response deleteClinicById(@PathParam("id") Long id) {
+        try {
+            deleteClinicPhotoByIdUseCase.execute(id);
+            return Response
+                    .ok(ResponseDTO.success("ClinicPhoto Deleted"))
+                    .build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/services/FileStorageServiceImpl.java
+++ b/src/main/java/com/medspace/infrastructure/services/FileStorageServiceImpl.java
@@ -1,0 +1,14 @@
+package com.medspace.infrastructure.services;
+
+import com.medspace.application.service.external.FileStorageService;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.io.InputStream;
+
+@ApplicationScoped
+public class FileStorageServiceImpl implements FileStorageService {
+    public String saveFile(InputStream inputStream) {
+        // TODO: use buckets
+        return "http://sample-endpoint.com";
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements the `ClinicPhoto` model, following CLEAN architecture coding standards. It allows the API to create, read, and delete ClinicPhoto models

## Context
The model is implemented according to this [design](https://drawsql.app/teams/jose-luis-team/diagrams/medspace)
It is part of this Jira [task](https://paez-tec.atlassian.net/browse/MED-75?atlOrigin=eyJpIjoiYjI5MGZmMzJmNDFhNDY0ODlhYTk1YjFhMDcyYjViMzEiLCJwIjoiaiJ9)

## Changes
Implemented entity:
- `ClinicPhoto`

Implemented use cases:
- `AssignPhotoToClinicUseCase` 
- `CreateClinicPhotoUseCase` 
- `DeleteClinicPhotoByIdUseCase` 
- `GetClinicPhotoByIdUseCase`
- `GetPhotosByClinicIdUseCase`
- `SetPhotoAsPrimaryUseCase`

Update `ClinicController` with the following endpoints:
- `POST /clinics/{id}/photos` - Returns a list of all ClinicPhotos of given Clinic
- `PUT /clinics/{id}/primary-photo` - Updates the primary photo of given Clinic

Create `ClinicPhotoController` with the following endpoints:
- `POST /clinic-photos` - Creates a new ClinicPhoto entity
- `DELETE /clinic-photos/{id}` - Deletes the ClinicPhoto with the given id

## Test Plan
Tested manually the new ClinicController and ClinicPhotoController endpoints to confirm that the returned JSON has correct format:

**POST /clinics/{id}/photos**
<img width="897" alt="Captura de pantalla 2025-04-18 a la(s) 7 06 44 p m" src="https://github.com/user-attachments/assets/3e07e708-1a2a-406b-b75f-44e99d319ddf" />

**PUT /clinics/{id}/primary-photo**
<img width="856" alt="Captura de pantalla 2025-04-18 a la(s) 7 07 20 p m" src="https://github.com/user-attachments/assets/03094b1d-dae8-44b4-afa9-b7bdf954b695" />

**POST /clinic-photos**
<img width="837" alt="Captura de pantalla 2025-04-18 a la(s) 7 07 45 p m" src="https://github.com/user-attachments/assets/5c8a1cda-bb40-4129-87d2-5a07a7ee227e" />

**DELETE /clinic-photos/{id}**
<img width="835" alt="Captura de pantalla 2025-04-18 a la(s) 7 08 14 p m" src="https://github.com/user-attachments/assets/4ec6b52f-d533-436b-a88e-5e89ad7c68f8" />