### PR TITLE
Feature: Add ClinicEquipment model

### DIFF
--- a/src/main/java/com/medspace/application/service/ClinicEquipmentService.java
+++ b/src/main/java/com/medspace/application/service/ClinicEquipmentService.java
@@ -1,0 +1,37 @@
+package com.medspace.application.service;
+
+import com.medspace.domain.model.ClinicEquipment;
+import com.medspace.domain.repository.ClinicEquipmentRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Instant;
+import java.util.List;
+
+@ApplicationScoped
+public class ClinicEquipmentService {
+    @Inject
+    ClinicEquipmentRepository clinicEquipmentRepository;
+
+    public ClinicEquipment createEquipment(ClinicEquipment clinicEquipment) {
+        clinicEquipment.setCreatedAt(Instant.now());
+        clinicEquipment = clinicEquipmentRepository.insertEquipment(clinicEquipment);
+        return clinicEquipment;
+    }
+
+    public ClinicEquipment assignEquipmentToClinic(Long clinicEquipmentId, Long clinicId) {
+        return clinicEquipmentRepository.assignEquipmentToClinic(clinicEquipmentId, clinicId);
+    }
+
+    public List<ClinicEquipment> getEquipmentsByClinicId(Long clinicId) {
+        return clinicEquipmentRepository.getEquipmentsByClinicId(clinicId);
+    }
+
+    public void deleteEquipmentById(Long id) {
+        clinicEquipmentRepository.deleteEquipmentById(id);
+    }
+
+    public ClinicEquipment getEquipmentById(Long id) {
+        return clinicEquipmentRepository.getEquipmentById(id);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicEquipment/AssignEquipmentToClinicUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicEquipment/AssignEquipmentToClinicUseCase.java
@@ -1,0 +1,16 @@
+package com.medspace.application.usecase.clinicEquipment;
+
+import com.medspace.application.service.ClinicEquipmentService;
+import com.medspace.domain.model.ClinicEquipment;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class AssignEquipmentToClinicUseCase {
+    @Inject
+    ClinicEquipmentService clinicEquipmentService;
+
+    public ClinicEquipment execute(Long clinicEquipmentId, Long clinicId) {
+        return clinicEquipmentService.assignEquipmentToClinic(clinicEquipmentId, clinicId);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicEquipment/CreateClinicEquipmentUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicEquipment/CreateClinicEquipmentUseCase.java
@@ -1,0 +1,16 @@
+package com.medspace.application.usecase.clinicEquipment;
+
+import com.medspace.application.service.ClinicEquipmentService;
+import com.medspace.domain.model.ClinicEquipment;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class CreateClinicEquipmentUseCase {
+    @Inject
+    ClinicEquipmentService clinicEquipmentService;
+
+    public ClinicEquipment execute(ClinicEquipment clinicEquipment) {
+        return clinicEquipmentService.createEquipment(clinicEquipment);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicEquipment/DeleteClinicEquipmentByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicEquipment/DeleteClinicEquipmentByIdUseCase.java
@@ -1,0 +1,15 @@
+package com.medspace.application.usecase.clinicEquipment;
+
+import com.medspace.application.service.ClinicEquipmentService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class DeleteClinicEquipmentByIdUseCase {
+    @Inject
+    ClinicEquipmentService clinicEquipmentService;
+
+    public void execute(Long id) {
+        clinicEquipmentService.deleteEquipmentById(id);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicEquipment/GetEquipmentsByClinicIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicEquipment/GetEquipmentsByClinicIdUseCase.java
@@ -1,0 +1,28 @@
+package com.medspace.application.usecase.clinicEquipment;
+
+import com.medspace.application.service.ClinicEquipmentService;
+import com.medspace.domain.model.ClinicEquipment;
+import com.medspace.infrastructure.dto.GetClinicEquipmentDTO;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class GetEquipmentsByClinicIdUseCase {
+    @Inject
+    ClinicEquipmentService clinicEquipmentService;
+
+    public List<GetClinicEquipmentDTO> execute(Long id) {
+        List<ClinicEquipment> clinicEquipments = clinicEquipmentService.getEquipmentsByClinicId(id);
+        List<GetClinicEquipmentDTO> clinicEquipmentDTOs = new ArrayList<>();
+
+        for(ClinicEquipment clinicEquipment : clinicEquipments) {
+            clinicEquipmentDTOs.add(new GetClinicEquipmentDTO(clinicEquipment));
+        }
+
+        return clinicEquipmentDTOs;
+    }
+}

--- a/src/main/java/com/medspace/domain/model/ClinicEquipment.java
+++ b/src/main/java/com/medspace/domain/model/ClinicEquipment.java
@@ -1,0 +1,22 @@
+package com.medspace.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+public class ClinicEquipment {
+    private Long id;
+    private String type;
+    private Integer quantity;
+
+    private Clinic clinic;
+
+    private Instant createdAt;
+}

--- a/src/main/java/com/medspace/domain/repository/ClinicEquipmentRepository.java
+++ b/src/main/java/com/medspace/domain/repository/ClinicEquipmentRepository.java
@@ -1,0 +1,13 @@
+package com.medspace.domain.repository;
+
+import com.medspace.domain.model.ClinicEquipment;
+
+import java.util.List;
+
+public interface ClinicEquipmentRepository {
+    public ClinicEquipment insertEquipment(ClinicEquipment clinicEquipment);
+    public ClinicEquipment getEquipmentById(Long id);
+    public void deleteEquipmentById(Long id);
+    public ClinicEquipment assignEquipmentToClinic(Long clinicEquipmentId, Long clinicId);
+    public List<ClinicEquipment> getEquipmentsByClinicId(Long clinicId);
+}

--- a/src/main/java/com/medspace/infrastructure/dto/CreateClinicEquipmentDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/CreateClinicEquipmentDTO.java
@@ -1,0 +1,31 @@
+package com.medspace.infrastructure.dto;
+
+import com.medspace.domain.model.ClinicEquipment;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateClinicEquipmentDTO {
+    @NotNull
+    private Long clinicId;
+
+    @NotNull
+    private Integer quantity;
+
+    @NotBlank
+    private String type;
+
+    public ClinicEquipment toClinicEquipment() {
+        ClinicEquipment clinicEquipment = new ClinicEquipment();
+        clinicEquipment.setType(type);
+        clinicEquipment.setQuantity(quantity);
+        return clinicEquipment;
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/dto/GetClinicEquipmentDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/GetClinicEquipmentDTO.java
@@ -1,0 +1,25 @@
+package com.medspace.infrastructure.dto;
+
+import com.medspace.domain.model.ClinicEquipment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetClinicEquipmentDTO {
+    private Long id;
+    private Long clinicId;
+    private Integer quantity;
+    private String type;
+
+    public GetClinicEquipmentDTO(ClinicEquipment clinicEquipment) {
+        this.id = clinicEquipment.getId();
+        this.clinicId = clinicEquipment.getClinic().getId();
+        this.quantity = clinicEquipment.getQuantity();
+        this.type = clinicEquipment.getType();
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/entity/ClinicEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/ClinicEntity.java
@@ -64,4 +64,7 @@ public class ClinicEntity {
 
     @OneToMany(mappedBy = "clinic", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Set<ClinicPhotoEntity> photos;
+
+    @OneToMany(mappedBy = "clinic", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Set<ClinicEquipmentEntity> equipments;
 }

--- a/src/main/java/com/medspace/infrastructure/entity/ClinicEquipmentEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/ClinicEquipmentEntity.java
@@ -1,0 +1,34 @@
+package com.medspace.infrastructure.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "clinic_equipments")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClinicEquipmentEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "type", nullable = false)
+    private String type;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "clinic_id")
+    private ClinicEntity clinic;
+}

--- a/src/main/java/com/medspace/infrastructure/mapper/ClinicEquipmentMapper.java
+++ b/src/main/java/com/medspace/infrastructure/mapper/ClinicEquipmentMapper.java
@@ -1,0 +1,40 @@
+package com.medspace.infrastructure.mapper;
+
+import com.medspace.domain.model.ClinicEquipment;
+import com.medspace.infrastructure.entity.ClinicEquipmentEntity;
+
+public class ClinicEquipmentMapper {
+    public static ClinicEquipment toDomain(ClinicEquipmentEntity clinicEquipmentEntity) {
+        if (clinicEquipmentEntity == null) {
+            return null;
+        }
+
+        ClinicEquipment clinicEquipment = new ClinicEquipment();
+        clinicEquipment.setId(clinicEquipmentEntity.getId());
+        clinicEquipment.setType(clinicEquipmentEntity.getType());
+        clinicEquipment.setQuantity(clinicEquipmentEntity.getQuantity());
+
+        clinicEquipment.setClinic(ClinicMapper.toDomain(clinicEquipmentEntity.getClinic()));
+
+        clinicEquipment.setCreatedAt(clinicEquipmentEntity.getCreatedAt());
+
+        return clinicEquipment;
+    }
+
+    public static ClinicEquipmentEntity toEntity(ClinicEquipment clinicEquipment) {
+        if (clinicEquipment == null) {
+            return null;
+        }
+
+        ClinicEquipmentEntity clinicEquipmentEntity = new ClinicEquipmentEntity();
+        clinicEquipmentEntity.setId(clinicEquipment.getId());
+        clinicEquipmentEntity.setType(clinicEquipment.getType());
+        clinicEquipmentEntity.setQuantity(clinicEquipment.getQuantity());
+
+        clinicEquipmentEntity.setClinic(ClinicMapper.toEntity(clinicEquipment.getClinic()));
+
+        clinicEquipmentEntity.setCreatedAt(clinicEquipment.getCreatedAt());
+
+        return clinicEquipmentEntity;
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/repository/ClinicEquipmentRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/ClinicEquipmentRepositoryImpl.java
@@ -1,0 +1,83 @@
+package com.medspace.infrastructure.repository;
+
+import com.medspace.domain.model.ClinicEquipment;
+import com.medspace.domain.repository.ClinicEquipmentRepository;
+import com.medspace.infrastructure.entity.ClinicEntity;
+import com.medspace.infrastructure.entity.ClinicEquipmentEntity;
+import com.medspace.infrastructure.mapper.ClinicEquipmentMapper;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.NotFoundException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ApplicationScoped
+public class ClinicEquipmentRepositoryImpl implements ClinicEquipmentRepository, PanacheRepositoryBase<ClinicEquipmentEntity, Long> {
+    @Inject
+    ClinicRepositoryImpl clinicRepository;
+
+    @Transactional
+    @Override
+    public ClinicEquipment insertEquipment(ClinicEquipment clinicEquipment) {
+        ClinicEquipmentEntity clinicEquipmentEntity = ClinicEquipmentMapper.toEntity(clinicEquipment);
+        persist(clinicEquipmentEntity);
+        clinicEquipment = ClinicEquipmentMapper.toDomain(clinicEquipmentEntity);
+        return clinicEquipment;
+    }
+
+    @Override
+    public ClinicEquipment getEquipmentById(Long id) {
+        ClinicEquipmentEntity clinicEquipmentEntity = findById(id);
+        if(clinicEquipmentEntity == null) {
+            throw new NotFoundException("ClinicEquipment with id " + id + " not found");
+        }
+        return ClinicEquipmentMapper.toDomain(clinicEquipmentEntity);
+    }
+
+    @Override
+    @Transactional
+    public void deleteEquipmentById(Long id) {
+        ClinicEquipmentEntity clinicEquipmentEntity = findById(id);
+        if(clinicEquipmentEntity != null) {
+           delete(clinicEquipmentEntity);
+        } else {
+            throw new NotFoundException("ClinicEquipment with id " + id + " not found");
+        }
+    }
+
+    @Override
+    @Transactional
+    public ClinicEquipment assignEquipmentToClinic(Long clinicEquipmentId, Long clinicId) {
+        ClinicEquipmentEntity clinicEquipmentEntity = findById(clinicEquipmentId);
+        if(clinicEquipmentEntity == null) {
+            throw new NotFoundException("ClinicEquipment with id " + clinicEquipmentId + " not found");
+        }
+
+        ClinicEntity clinicEntity = clinicRepository.findById(clinicId);
+        if(clinicEntity == null) {
+            throw new NotFoundException("Clinic with id " + clinicId + " not found");
+        }
+
+        clinicEquipmentEntity.setClinic(clinicEntity);
+        persist(clinicEquipmentEntity);
+        return ClinicEquipmentMapper.toDomain(clinicEquipmentEntity);
+    }
+
+    @Override
+    public List<ClinicEquipment> getEquipmentsByClinicId(Long clinicId) {
+        ClinicEntity clinicEntity = clinicRepository.findById(clinicId);
+        if(clinicEntity == null) {
+            throw new NotFoundException("Clinic with id " + clinicId + " not found");
+        }
+
+        List<ClinicEquipment> clinicEquipments = new ArrayList<>();
+        for(ClinicEquipmentEntity clinicEquipmentEntity : clinicEntity.getEquipments()) {
+            clinicEquipments.add(ClinicEquipmentMapper.toDomain(clinicEquipmentEntity));
+        }
+
+        return clinicEquipments;
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
@@ -1,14 +1,12 @@
 package com.medspace.infrastructure.rest;
 
 import com.medspace.application.usecase.clinic.*;
+import com.medspace.application.usecase.clinicEquipment.GetEquipmentsByClinicIdUseCase;
 import com.medspace.application.usecase.clinicPhoto.GetClinicPhotoByIdUseCase;
 import com.medspace.application.usecase.clinicPhoto.GetPhotosByClinicIdUseCase;
 import com.medspace.application.usecase.clinicPhoto.SetPhotoAsPrimaryClinicPhotoUseCase;
 import com.medspace.domain.model.Clinic;
-import com.medspace.infrastructure.dto.CreateClinicDTO;
-import com.medspace.infrastructure.dto.GetClinicPhotoDTO;
-import com.medspace.infrastructure.dto.ResponseDTO;
-import com.medspace.infrastructure.dto.SetPhotoAsPrimaryDTO;
+import com.medspace.infrastructure.dto.*;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -41,6 +39,8 @@ public class ClinicController {
     SetPhotoAsPrimaryClinicPhotoUseCase setPhotoAsPrimaryClinicPhotoUseCase;
     @Inject
     GetClinicPhotoByIdUseCase getClinicPhotoByIdUseCase;
+    @Inject
+    GetEquipmentsByClinicIdUseCase getEquipmentsByClinicIdUseCase;
 
     @POST
     @Transactional
@@ -140,6 +140,22 @@ public class ClinicController {
 
             return Response
                     .ok(ResponseDTO.success("Clinic Photo Updated"))
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        }
+    }
+
+    @GET
+    @Path("/{id}/equipments")
+    public Response getEquipmentsByClinicId(@PathParam("id") Long id) {
+        try {
+            List<GetClinicEquipmentDTO> clinicEquipments = getEquipmentsByClinicIdUseCase.execute(id);
+
+            return Response
+                    .ok(ResponseDTO.success("ClinicEquipment Fetched", clinicEquipments))
                     .build();
         } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/medspace/infrastructure/rest/ClinicEquipmentController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/ClinicEquipmentController.java
@@ -1,0 +1,65 @@
+package com.medspace.infrastructure.rest;
+
+import com.medspace.application.usecase.clinicEquipment.AssignEquipmentToClinicUseCase;
+import com.medspace.application.usecase.clinicEquipment.CreateClinicEquipmentUseCase;
+import com.medspace.application.usecase.clinicEquipment.DeleteClinicEquipmentByIdUseCase;
+import com.medspace.domain.model.ClinicEquipment;
+import com.medspace.infrastructure.dto.CreateClinicEquipmentDTO;
+import com.medspace.infrastructure.dto.ResponseDTO;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@ApplicationScoped
+@Path("/clinic-equipments")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class ClinicEquipmentController {
+    @Inject
+    CreateClinicEquipmentUseCase createClinicEquipmentUseCase;
+    @Inject
+    AssignEquipmentToClinicUseCase assignEquipmentToClinicUseCase;
+    @Inject
+    DeleteClinicEquipmentByIdUseCase deleteClinicEquipmentByIdUseCase;
+
+    @POST
+    @Transactional
+    public Response createClinicEquipment(@Valid CreateClinicEquipmentDTO equipmentRequest) {
+        try {
+            ClinicEquipment clinicEquipment = createClinicEquipmentUseCase
+                    .execute(equipmentRequest.toClinicEquipment());
+            assignEquipmentToClinicUseCase.execute(clinicEquipment.getId(), equipmentRequest.getClinicId());
+
+            return Response.status(Response.Status.CREATED)
+                    .entity(ResponseDTO.success("ClinicEquipment Created"))
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        }
+    }
+
+    @DELETE
+    @Path("/{id}")
+    public Response deleteClinicEquipmentById(@PathParam("id") Long id) {
+        try {
+            deleteClinicEquipmentByIdUseCase.execute(id);
+            return Response
+                    .ok(ResponseDTO.success("ClinicEquipment Deleted"))
+                    .build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements the `ClinicEquipment` model, following CLEAN architecture coding standards. It allows the API to create, read, and delete ClinicEquipment models

## Context
The model is implemented according to this [design](https://drawsql.app/teams/jose-luis-team/diagrams/medspace)
It is part of this Jira [task](https://paez-tec.atlassian.net/browse/MED-75?atlOrigin=eyJpIjoiYjI5MGZmMzJmNDFhNDY0ODlhYTk1YjFhMDcyYjViMzEiLCJwIjoiaiJ9)

## Changes
Implemented entity:
- `ClinicEquipment`

Implemented use cases:
- `AssignEquipmentToClinicUseCase` 
- `CreateClinicEquipmentUseCase` 
- `DeleteClinicEquipmentByIdUseCase` 
- `GetEquipmentsByClinicIdUseCase`

Update `ClinicController` with the following endpoints:
- `GET /clinics/{id}/equipments` - Returns a list of all ClinicEquipment of given Clinic

Create `ClinicEquipmentController` with the following endpoints:
- `POST /clinic-equipments` - Creates a new ClinicEquipment entity
- `DELETE /clinic-equipments/{id}` - Deletes the ClinicEquipment with the given id

## Test Plan
Tested manually the new ClinicController and ClinicPhotoController endpoints to confirm that the returned JSON has correct format:

**POST /clinic-equipments**
<img width="855" alt="Captura de pantalla 2025-04-18 a la(s) 10 36 25 p m" src="https://github.com/user-attachments/assets/3c6e8dc2-42f2-4616-841b-2966fd4d2e7a" />

**DELETE /clinic-equipments/{id}**
<img width="872" alt="Captura de pantalla 2025-04-18 a la(s) 10 37 26 p m" src="https://github.com/user-attachments/assets/3ca5fb66-66d0-4329-ab78-e48dc8e53794" />


**GET /clinics/{id}/equipments**
<img width="911" alt="Captura de pantalla 2025-04-18 a la(s) 10 37 06 p m" src="https://github.com/user-attachments/assets/d7cfa574-dbe6-4226-a47f-664505c66adb" />



