### PR TITLE
Feature: add ClinicAvailability model

### DIFF
--- a/src/main/java/com/medspace/application/service/ClinicAvailabilityService.java
+++ b/src/main/java/com/medspace/application/service/ClinicAvailabilityService.java
@@ -1,0 +1,37 @@
+package com.medspace.application.service;
+
+import com.medspace.domain.model.ClinicAvailability;
+import com.medspace.domain.repository.ClinicAvailabilityRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Instant;
+import java.util.List;
+
+@ApplicationScoped
+public class ClinicAvailabilityService {
+    @Inject
+    ClinicAvailabilityRepository clinicAvailabilityRepository;
+
+    public ClinicAvailability createAvailability(ClinicAvailability clinicAvailability) {
+        clinicAvailability.setCreatedAt(Instant.now());
+        clinicAvailability = clinicAvailabilityRepository.insertAvailability(clinicAvailability);
+        return clinicAvailability;
+    }
+
+    public ClinicAvailability assignAvailabilityToClinic(Long clinicAvailabilityId, Long clinicId) {
+        return clinicAvailabilityRepository.assignAvailabilityToClinic(clinicAvailabilityId, clinicId);
+    }
+
+    public List<ClinicAvailability> getAvailabilitiesByClinicId(Long clinicId) {
+        return clinicAvailabilityRepository.getAvailabilitiesByClinicId(clinicId);
+    }
+
+    public void deleteAvailabilityById(Long id) {
+        clinicAvailabilityRepository.deleteAvailabilityById(id);
+    }
+
+    public ClinicAvailability updateAvailabilityById(Long id, ClinicAvailability clinicAvailability) {
+        return clinicAvailabilityRepository.updateAvailability(id, clinicAvailability);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicAvailability/AssignAvailabilityToClinicUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicAvailability/AssignAvailabilityToClinicUseCase.java
@@ -1,0 +1,16 @@
+package com.medspace.application.usecase.clinicAvailability;
+
+import com.medspace.application.service.ClinicAvailabilityService;
+import com.medspace.domain.model.ClinicAvailability;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class AssignAvailabilityToClinicUseCase {
+    @Inject
+    ClinicAvailabilityService clinicAvailabilityService;
+
+    public ClinicAvailability execute(Long clinicAvailabilityId, Long clinicId) {
+        return clinicAvailabilityService.assignAvailabilityToClinic(clinicAvailabilityId, clinicId);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicAvailability/CreateClinicAvailabilityUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicAvailability/CreateClinicAvailabilityUseCase.java
@@ -1,0 +1,16 @@
+package com.medspace.application.usecase.clinicAvailability;
+
+import com.medspace.application.service.ClinicAvailabilityService;
+import com.medspace.domain.model.ClinicAvailability;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class CreateClinicAvailabilityUseCase {
+    @Inject
+    ClinicAvailabilityService clinicAvailabilityService;
+
+    public ClinicAvailability execute(ClinicAvailability clinicAvailability) {
+        return clinicAvailabilityService.createAvailability(clinicAvailability);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicAvailability/DeleteClinicAvailabilityByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicAvailability/DeleteClinicAvailabilityByIdUseCase.java
@@ -1,0 +1,15 @@
+package com.medspace.application.usecase.clinicAvailability;
+
+import com.medspace.application.service.ClinicAvailabilityService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class DeleteClinicAvailabilityByIdUseCase {
+    @Inject
+    ClinicAvailabilityService clinicAvailabilityService;
+
+    public void execute(Long id) {
+        clinicAvailabilityService.deleteAvailabilityById(id);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicAvailability/GetAvailabilitiesByClinicIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicAvailability/GetAvailabilitiesByClinicIdUseCase.java
@@ -1,0 +1,27 @@
+package com.medspace.application.usecase.clinicAvailability;
+
+import com.medspace.application.service.ClinicAvailabilityService;
+import com.medspace.domain.model.ClinicAvailability;
+import com.medspace.infrastructure.dto.GetClinicAvailabilityDTO;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ApplicationScoped
+public class GetAvailabilitiesByClinicIdUseCase {
+    @Inject
+    ClinicAvailabilityService clinicAvailabilityService;
+
+    public List<GetClinicAvailabilityDTO> execute(Long id) {
+        List<ClinicAvailability> clinicAvailabilities = clinicAvailabilityService.getAvailabilitiesByClinicId(id);
+        List<GetClinicAvailabilityDTO> clinicAvailabilityDTOS = new ArrayList<>();
+
+        for(ClinicAvailability clinicAvailability : clinicAvailabilities){
+            clinicAvailabilityDTOS.add(new GetClinicAvailabilityDTO(clinicAvailability));
+        }
+
+        return clinicAvailabilityDTOS;
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicAvailability/UpdateClinicAvailabilityUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicAvailability/UpdateClinicAvailabilityUseCase.java
@@ -1,0 +1,16 @@
+package com.medspace.application.usecase.clinicAvailability;
+
+import com.medspace.application.service.ClinicAvailabilityService;
+import com.medspace.domain.model.ClinicAvailability;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class UpdateClinicAvailabilityUseCase {
+    @Inject
+    ClinicAvailabilityService clinicAvailabilityService;
+
+    public ClinicAvailability execute(Long id, ClinicAvailability clinicAvailability) {
+        return clinicAvailabilityService.updateAvailabilityById(id, clinicAvailability);
+    }
+}

--- a/src/main/java/com/medspace/domain/model/ClinicAvailability.java
+++ b/src/main/java/com/medspace/domain/model/ClinicAvailability.java
@@ -1,0 +1,34 @@
+package com.medspace.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.time.LocalTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+public class ClinicAvailability {
+    public enum WeekDay {
+        MONDAY,
+        TUESDAY,
+        WEDNESDAY,
+        THURSDAY,
+        FRIDAY,
+        SATURDAY,
+        SUNDAY
+    }
+
+    private Long id;
+    private WeekDay weekDay;
+    private LocalTime startTime;
+    private LocalTime endTime;
+
+    private Clinic clinic;
+
+    private Instant createdAt;
+}

--- a/src/main/java/com/medspace/domain/repository/ClinicAvailabilityRepository.java
+++ b/src/main/java/com/medspace/domain/repository/ClinicAvailabilityRepository.java
@@ -1,0 +1,13 @@
+package com.medspace.domain.repository;
+
+import com.medspace.domain.model.ClinicAvailability;
+
+import java.util.List;
+
+public interface ClinicAvailabilityRepository {
+    public ClinicAvailability insertAvailability(ClinicAvailability clinicAvailability);
+    public ClinicAvailability updateAvailability(Long id, ClinicAvailability clinicAvailability);
+    public void deleteAvailabilityById(Long id);
+    public ClinicAvailability assignAvailabilityToClinic(Long clinicAvailabilityId, Long clinicId);
+    public List<ClinicAvailability> getAvailabilitiesByClinicId(Long clinicId);
+}

--- a/src/main/java/com/medspace/infrastructure/dto/CreateClinicAvailabilityDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/CreateClinicAvailabilityDTO.java
@@ -1,0 +1,42 @@
+package com.medspace.infrastructure.dto;
+
+import com.medspace.domain.model.ClinicAvailability;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateClinicAvailabilityDTO {
+    @NotNull
+    private Long clinicId;
+
+    @NotNull
+    private LocalTime startTime;
+
+    @NotNull
+    private LocalTime endTime;
+
+    @NotNull
+    @Pattern(regexp = "MONDAY|TUESDAY|WEDNESDAY|THURSDAY|FRIDAY|SATURDAY|SUNDAY",
+            message = "WeekDay type must be a day of the week")
+    private String weekDay;
+
+    public ClinicAvailability toClinicAvailability() {
+        ClinicAvailability clinicAvailability = new ClinicAvailability();
+
+        clinicAvailability.setStartTime(startTime);
+        clinicAvailability.setEndTime(endTime);
+        clinicAvailability.setWeekDay(ClinicAvailability.WeekDay.valueOf(weekDay));
+
+        return clinicAvailability;
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/dto/GetClinicAvailabilityDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/GetClinicAvailabilityDTO.java
@@ -1,0 +1,30 @@
+package com.medspace.infrastructure.dto;
+
+import com.medspace.domain.model.ClinicAvailability;
+import com.medspace.domain.model.ClinicEquipment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetClinicAvailabilityDTO {
+    private Long id;
+    private Long clinicId;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private ClinicAvailability.WeekDay weekDay;
+
+    public GetClinicAvailabilityDTO(ClinicAvailability clinicAvailability) {
+        this.id = clinicAvailability.getId();
+        this.clinicId = clinicAvailability.getClinic().getId();
+        this.startTime = clinicAvailability.getStartTime();
+        this.endTime = clinicAvailability.getEndTime();
+        this.weekDay = clinicAvailability.getWeekDay();
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/dto/UpdateClinicAvailabilityDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/UpdateClinicAvailabilityDTO.java
@@ -1,0 +1,38 @@
+package com.medspace.infrastructure.dto;
+
+import com.medspace.domain.model.ClinicAvailability;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateClinicAvailabilityDTO {
+    @NotNull
+    private LocalTime startTime;
+
+    @NotNull
+    private LocalTime endTime;
+
+    @NotNull
+    @Pattern(regexp = "MONDAY|TUESDAY|WEDNESDAY|THURSDAY|FRIDAY|SATURDAY|SUNDAY",
+            message = "WeekDay type must be a day of the week")
+    private String weekDay;
+
+    public ClinicAvailability toClinicAvailability() {
+        ClinicAvailability clinicAvailability = new ClinicAvailability();
+
+        clinicAvailability.setStartTime(startTime);
+        clinicAvailability.setEndTime(endTime);
+        clinicAvailability.setWeekDay(ClinicAvailability.WeekDay.valueOf(weekDay));
+
+        return clinicAvailability;
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/entity/ClinicAvailabilityEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/ClinicAvailabilityEntity.java
@@ -1,0 +1,40 @@
+package com.medspace.infrastructure.entity;
+
+import com.medspace.domain.model.ClinicAvailability;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "clinic_availabilities")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClinicAvailabilityEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "week_day", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ClinicAvailability.WeekDay weekDay;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "clinic_id")
+    private ClinicEntity clinic;
+}

--- a/src/main/java/com/medspace/infrastructure/entity/ClinicEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/ClinicEntity.java
@@ -67,4 +67,7 @@ public class ClinicEntity {
 
     @OneToMany(mappedBy = "clinic", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Set<ClinicEquipmentEntity> equipments;
+
+    @OneToMany(mappedBy = "clinic", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Set<ClinicAvailabilityEntity> availabilities;
 }

--- a/src/main/java/com/medspace/infrastructure/mapper/ClinicAvailabilityMapper.java
+++ b/src/main/java/com/medspace/infrastructure/mapper/ClinicAvailabilityMapper.java
@@ -1,0 +1,42 @@
+package com.medspace.infrastructure.mapper;
+
+import com.medspace.domain.model.ClinicAvailability;
+import com.medspace.infrastructure.entity.ClinicAvailabilityEntity;
+
+public class ClinicAvailabilityMapper {
+    public static ClinicAvailability toDomain(ClinicAvailabilityEntity clinicAvailabilityEntity) {
+        if (clinicAvailabilityEntity == null) {
+            return null;
+        }
+
+        ClinicAvailability clinicAvailability = new ClinicAvailability();
+        clinicAvailability.setId(clinicAvailabilityEntity.getId());
+        clinicAvailability.setWeekDay(clinicAvailabilityEntity.getWeekDay());
+        clinicAvailability.setStartTime(clinicAvailabilityEntity.getStartTime());
+        clinicAvailability.setEndTime(clinicAvailabilityEntity.getEndTime());
+
+        clinicAvailability.setClinic(ClinicMapper.toDomain(clinicAvailabilityEntity.getClinic()));
+
+        clinicAvailability.setCreatedAt(clinicAvailabilityEntity.getCreatedAt());
+
+        return clinicAvailability;
+    }
+
+    public static ClinicAvailabilityEntity toEntity(ClinicAvailability clinicAvailability) {
+        if (clinicAvailability == null) {
+            return null;
+        }
+
+        ClinicAvailabilityEntity clinicAvailabilityEntity = new ClinicAvailabilityEntity();
+        clinicAvailabilityEntity.setId(clinicAvailability.getId());
+        clinicAvailabilityEntity.setWeekDay(clinicAvailability.getWeekDay());
+        clinicAvailabilityEntity.setStartTime(clinicAvailability.getStartTime());
+        clinicAvailabilityEntity.setEndTime(clinicAvailability.getEndTime());
+
+        clinicAvailabilityEntity.setClinic(ClinicMapper.toEntity(clinicAvailability.getClinic()));
+
+        clinicAvailabilityEntity.setCreatedAt(clinicAvailability.getCreatedAt());
+
+        return clinicAvailabilityEntity;
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/repository/ClinicAvailabilityRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/ClinicAvailabilityRepositoryImpl.java
@@ -59,9 +59,9 @@ public class ClinicAvailabilityRepositoryImpl implements ClinicAvailabilityRepos
     @Override
     @Transactional
     public ClinicAvailability assignAvailabilityToClinic(Long clinicAvailabilityId, Long clinicId) {
-        ClinicAvailabilityEntity clinicAvailabilityEntity = findById(clinicId);
+        ClinicAvailabilityEntity clinicAvailabilityEntity = findById(clinicAvailabilityId);
         if (clinicAvailabilityEntity == null) {
-            throw new NotFoundException("ClinicAvailability with id " + clinicId + " not found");
+            throw new NotFoundException("ClinicAvailability with id " + clinicAvailabilityId + " not found");
         }
 
         ClinicEntity clinicEntity = clinicRepository.findById(clinicId);

--- a/src/main/java/com/medspace/infrastructure/repository/ClinicAvailabilityRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/ClinicAvailabilityRepositoryImpl.java
@@ -1,0 +1,90 @@
+package com.medspace.infrastructure.repository;
+
+import com.medspace.domain.model.ClinicAvailability;
+import com.medspace.domain.repository.ClinicAvailabilityRepository;
+import com.medspace.infrastructure.entity.ClinicAvailabilityEntity;
+import com.medspace.infrastructure.entity.ClinicEntity;
+import com.medspace.infrastructure.mapper.ClinicAvailabilityMapper;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.NotFoundException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ApplicationScoped
+public class ClinicAvailabilityRepositoryImpl implements ClinicAvailabilityRepository,
+        PanacheRepositoryBase<ClinicAvailabilityEntity, Long> {
+    @Inject
+    ClinicRepositoryImpl clinicRepository;
+
+    @Transactional
+    @Override
+    public ClinicAvailability insertAvailability(ClinicAvailability clinicAvailability) {
+        ClinicAvailabilityEntity clinicAvailabilityEntity = ClinicAvailabilityMapper.toEntity(clinicAvailability);
+        persist(clinicAvailabilityEntity);
+        clinicAvailability = ClinicAvailabilityMapper.toDomain(clinicAvailabilityEntity);
+        return clinicAvailability;
+    }
+
+    @Override
+    @Transactional
+    public ClinicAvailability updateAvailability(Long id, ClinicAvailability clinicAvailability) {
+        ClinicAvailabilityEntity clinicAvailabilityEntity = findById(id);
+        if (clinicAvailabilityEntity == null) {
+            throw new NotFoundException("ClinicAvailability with id " + id + " not found");
+        }
+
+        clinicAvailabilityEntity.setWeekDay(clinicAvailability.getWeekDay());
+        clinicAvailabilityEntity.setStartTime(clinicAvailability.getStartTime());
+        clinicAvailabilityEntity.setEndTime(clinicAvailability.getEndTime());
+
+        persist(clinicAvailabilityEntity);
+        return ClinicAvailabilityMapper.toDomain(clinicAvailabilityEntity);
+    }
+
+    @Override
+    @Transactional
+    public void deleteAvailabilityById(Long id) {
+        ClinicAvailabilityEntity clinicAvailabilityEntity = findById(id);
+        if (clinicAvailabilityEntity != null) {
+            delete(clinicAvailabilityEntity);
+        } else {
+            throw new NotFoundException("ClinicAvailability with id " + id + " not found");
+        }
+    }
+
+    @Override
+    @Transactional
+    public ClinicAvailability assignAvailabilityToClinic(Long clinicAvailabilityId, Long clinicId) {
+        ClinicAvailabilityEntity clinicAvailabilityEntity = findById(clinicId);
+        if (clinicAvailabilityEntity == null) {
+            throw new NotFoundException("ClinicAvailability with id " + clinicId + " not found");
+        }
+
+        ClinicEntity clinicEntity = clinicRepository.findById(clinicId);
+        if (clinicEntity == null) {
+            throw new NotFoundException("Clinic with id " + clinicId + " not found");
+        }
+
+        clinicAvailabilityEntity.setClinic(clinicEntity);
+        persist(clinicAvailabilityEntity);
+        return ClinicAvailabilityMapper.toDomain(clinicAvailabilityEntity);
+    }
+
+    public List<ClinicAvailability> getAvailabilitiesByClinicId(Long clinicId) {
+        ClinicEntity clinicEntity = clinicRepository.findById(clinicId);
+        if (clinicEntity == null) {
+            throw new NotFoundException("Clinic with id " + clinicId + " not found");
+        }
+
+        List<ClinicAvailability> clinicAvailabilities = new ArrayList<>();
+        for(ClinicAvailabilityEntity clinicAvailabilityEntity : clinicEntity.getAvailabilities()) {
+            clinicAvailabilities.add(ClinicAvailabilityMapper.toDomain(clinicAvailabilityEntity));
+        }
+
+        return clinicAvailabilities;
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/rest/ClinicAvailabilityController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/ClinicAvailabilityController.java
@@ -1,0 +1,85 @@
+package com.medspace.infrastructure.rest;
+
+import com.medspace.application.usecase.clinicAvailability.AssignAvailabilityToClinicUseCase;
+import com.medspace.application.usecase.clinicAvailability.CreateClinicAvailabilityUseCase;
+import com.medspace.application.usecase.clinicAvailability.DeleteClinicAvailabilityByIdUseCase;
+import com.medspace.application.usecase.clinicAvailability.UpdateClinicAvailabilityUseCase;
+import com.medspace.domain.model.ClinicAvailability;
+import com.medspace.infrastructure.dto.CreateClinicAvailabilityDTO;
+import com.medspace.infrastructure.dto.ResponseDTO;
+import com.medspace.infrastructure.dto.UpdateClinicAvailabilityDTO;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@ApplicationScoped
+@Path("/clinic-availabilities")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class ClinicAvailabilityController {
+    @Inject
+    CreateClinicAvailabilityUseCase createClinicAvailabilityUseCase;
+    @Inject
+    AssignAvailabilityToClinicUseCase assignAvailabilityToClinicUseCase;
+    @Inject
+    DeleteClinicAvailabilityByIdUseCase deleteClinicAvailabilityByIdUseCase;
+    @Inject
+    UpdateClinicAvailabilityUseCase updateClinicAvailabilityUseCase;
+
+    @POST
+    @Transactional
+    public Response createClinicAvailability(@Valid CreateClinicAvailabilityDTO availabilityRequest) {
+        try {
+            ClinicAvailability clinicAvailability = createClinicAvailabilityUseCase
+                    .execute(availabilityRequest.toClinicAvailability());
+            assignAvailabilityToClinicUseCase.execute(clinicAvailability.getId(), availabilityRequest.getClinicId());
+
+            return Response.status(Response.Status.CREATED)
+                    .entity(ResponseDTO.success("ClinicAvailability Created"))
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        }
+    }
+
+    @DELETE
+    @Path("/{id}")
+    public Response deleteClinicAvailabilityById(@PathParam("id") Long id) {
+        try {
+            deleteClinicAvailabilityByIdUseCase.execute(id);
+            return Response
+                    .ok(ResponseDTO.success("ClinicAvailability Deleted"))
+                    .build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        }
+    }
+
+    @PUT
+    @Path("/{id}")
+    public Response updateClinicAvailabilityById(@PathParam("id") Long id,
+                                                 @Valid UpdateClinicAvailabilityDTO availabilityRequest) {
+        try {
+            updateClinicAvailabilityUseCase.execute(id, availabilityRequest.toClinicAvailability());
+            return Response
+                    .ok(ResponseDTO.success("ClinicAvailability Updated"))
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
@@ -1,6 +1,7 @@
 package com.medspace.infrastructure.rest;
 
 import com.medspace.application.usecase.clinic.*;
+import com.medspace.application.usecase.clinicAvailability.GetAvailabilitiesByClinicIdUseCase;
 import com.medspace.application.usecase.clinicEquipment.GetEquipmentsByClinicIdUseCase;
 import com.medspace.application.usecase.clinicPhoto.GetClinicPhotoByIdUseCase;
 import com.medspace.application.usecase.clinicPhoto.GetPhotosByClinicIdUseCase;
@@ -41,6 +42,8 @@ public class ClinicController {
     GetClinicPhotoByIdUseCase getClinicPhotoByIdUseCase;
     @Inject
     GetEquipmentsByClinicIdUseCase getEquipmentsByClinicIdUseCase;
+    @Inject
+    GetAvailabilitiesByClinicIdUseCase getAvailabilitiesByClinicIdUseCase;
 
     @POST
     @Transactional
@@ -156,6 +159,22 @@ public class ClinicController {
 
             return Response
                     .ok(ResponseDTO.success("ClinicEquipment Fetched", clinicEquipments))
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage()))
+                    .build();
+        }
+    }
+
+    @GET
+    @Path("/{id}/availabilities")
+    public Response getAvailabilitiesByClinicId(@PathParam("id") Long id) {
+        try {
+            List<GetClinicAvailabilityDTO> clinicAvailabilities = getAvailabilitiesByClinicIdUseCase.execute(id);
+
+            return Response
+                    .ok(ResponseDTO.success("ClinicAvailability Fetched", clinicAvailabilities))
                     .build();
         } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## Summary
This PR implements the `ClinicAvailability` model, following CLEAN architecture coding standards. It allows the API to create, read, and delete ClinicAvailability models

## Context
The model is implemented according to this [design](https://drawsql.app/teams/jose-luis-team/diagrams/medspace)
It is part of this Jira [task](https://paez-tec.atlassian.net/browse/MED-75?atlOrigin=eyJpIjoiYjI5MGZmMzJmNDFhNDY0ODlhYTk1YjFhMDcyYjViMzEiLCJwIjoiaiJ9)

## Changes
Implemented entity:
- `ClinicAvailability`

Implemented use cases:
- `AssignAvailabilityToClinicUseCase` 
- `CreateClinicAvailabilityUseCase` 
- `DeleteClinicAvailabilityByIdUseCase` 
- `GetAvailabilitiesByClinicIdUseCase`
- `UpdateClinicAvailabilityUseCase`

Update `ClinicController` with the following endpoints:
- `GET /clinics/{id}/availabilities` - Returns a list of all ClinicEquipment of given Clinic

Create `ClinicAvailabilityController` with the following endpoints:
- `POST /clinic-availabilities` - Creates a new ClinicAvailability entity
- `DELETE /clinic-availabilities/{id}` - Deletes the ClinicAvailability with the given id
- `PUT /clinic-availabilities/{id}` - Updates the ClinicAvailability with the given id

## Test Plan
Tested manually the new ClinicController and ClinicAvailabilityController endpoints to confirm that the returned JSON has correct format:

**GET /clinics/{id}/availabilities**
<img width="872" alt="Captura de pantalla 2025-04-19 a la(s) 11 33 04 a m" src="https://github.com/user-attachments/assets/d8bf039a-730d-47ff-a43b-536b98ea4e56" />

**POST /clinic-availabilities**
<img width="876" alt="Captura de pantalla 2025-04-19 a la(s) 11 32 12 a m" src="https://github.com/user-attachments/assets/67968681-4458-46f9-92bf-117c72823b5f" />

**PUT /clinic-availabilities/{id}**
<img width="870" alt="Captura de pantalla 2025-04-19 a la(s) 11 33 43 a m" src="https://github.com/user-attachments/assets/5541cf36-cca0-4988-9f50-e2fe7bbe7789" />

**DELETE /clinic-availabilities/{id}**
<img width="889" alt="Captura de pantalla 2025-04-19 a la(s) 11 34 13 a m" src="https://github.com/user-attachments/assets/b913e2d3-2e5b-4ccb-b6ef-ac23e1033b40" />

