### PR TITLE
Refactor: Add authentication to Clinic resources

### DIFF
--- a/src/main/java/com/medspace/application/service/ClinicAvailabilityService.java
+++ b/src/main/java/com/medspace/application/service/ClinicAvailabilityService.java
@@ -36,4 +36,8 @@ public class ClinicAvailabilityService {
             ClinicAvailability clinicAvailability) {
         return clinicAvailabilityRepository.updateAvailability(id, clinicAvailability);
     }
+
+    public ClinicAvailability getAvailabilityById(Long id) {
+        return clinicAvailabilityRepository.getAvailabilityById(id);
+    }
 }

--- a/src/main/java/com/medspace/application/service/ClinicPhotoService.java
+++ b/src/main/java/com/medspace/application/service/ClinicPhotoService.java
@@ -46,4 +46,16 @@ public class ClinicPhotoService {
     public void setPhotoAsPrimary(Long id) {
         clinicPhotoRepository.setPhotoAsPrimary(id);
     }
+
+    public Boolean validatePhotoOwnership(Long photoId, Long clinicId) {
+        if (photoId == null || clinicId == null) {
+            return false;
+        }
+
+        ClinicPhoto clinicPhoto = clinicPhotoRepository.getPhotoById(photoId);
+        if (clinicPhoto == null) {
+            return false;
+        }
+        return clinicPhoto.getClinic().getId().equals(clinicId);
+    }
 }

--- a/src/main/java/com/medspace/application/service/ClinicService.java
+++ b/src/main/java/com/medspace/application/service/ClinicService.java
@@ -31,7 +31,23 @@ public class ClinicService {
         return clinicRepository.getAllClinics();
     }
 
+    public List<Clinic> getClinicsByLandlordId(Long landlordId) {
+        return clinicRepository.getClinicsByLandlordId(landlordId);
+    }
+
     public Clinic assignLandlord(Long clinicId, Long userId) {
         return clinicRepository.assignClinicToUser(clinicId, userId);
+    }
+
+    public Boolean validateClinicOwnership(Long clinicId, Long userId) {
+        if (clinicId == null || userId == null) {
+            return false;
+        }
+
+        Clinic clinic = clinicRepository.getClinicById(clinicId);
+        if (clinic == null) {
+            return false;
+        }
+        return clinic.getLandlord().getId().equals(userId);
     }
 }

--- a/src/main/java/com/medspace/application/usecase/clinic/DeleteClinicByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinic/DeleteClinicByIdUseCase.java
@@ -1,10 +1,10 @@
 package com.medspace.application.usecase.clinic;
 
 import com.medspace.application.service.ClinicService;
+import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class DeleteClinicByIdUseCase {

--- a/src/main/java/com/medspace/application/usecase/clinic/DeleteClinicByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinic/DeleteClinicByIdUseCase.java
@@ -3,13 +3,21 @@ package com.medspace.application.usecase.clinic;
 import com.medspace.application.service.ClinicService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class DeleteClinicByIdUseCase {
     @Inject
     ClinicService clinicService;
 
-    public void execute(Long id) {
+    @Transactional
+    public void execute(Long id, Long loggedUserId) {
+        Boolean isOwner = clinicService.validateClinicOwnership(id, loggedUserId);
+        if (!isOwner) {
+            throw new ForbiddenException("Delete unauthorized");
+        }
+
         clinicService.deleteClinicById(id);
     }
 }

--- a/src/main/java/com/medspace/application/usecase/clinic/GetClinicByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinic/GetClinicByIdUseCase.java
@@ -4,6 +4,7 @@ import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.Clinic;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.NotFoundException;
 
 @ApplicationScoped
 public class GetClinicByIdUseCase {
@@ -11,6 +12,10 @@ public class GetClinicByIdUseCase {
     ClinicService clinicService;
 
     public Clinic execute(Long id) {
-        return clinicService.getClinicById(id);
+        Clinic clinic = clinicService.getClinicById(id);
+        if (clinic == null) {
+            throw new NotFoundException("Clinic with id " + id + " not found");
+        }
+        return clinic;
     }
 }

--- a/src/main/java/com/medspace/application/usecase/clinic/GetClinicsByLandlordIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinic/GetClinicsByLandlordIdUseCase.java
@@ -1,0 +1,17 @@
+package com.medspace.application.usecase.clinic;
+
+import java.util.List;
+import com.medspace.application.service.ClinicService;
+import com.medspace.domain.model.Clinic;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class GetClinicsByLandlordIdUseCase {
+    @Inject
+    ClinicService clinicService;
+
+    public List<Clinic> execute(Long landlordId) {
+        return clinicService.getClinicsByLandlordId(landlordId);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinicAvailability/AssignAvailabilityToClinicUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicAvailability/AssignAvailabilityToClinicUseCase.java
@@ -3,10 +3,10 @@ package com.medspace.application.usecase.clinicAvailability;
 import com.medspace.application.service.ClinicAvailabilityService;
 import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.ClinicAvailability;
+import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class AssignAvailabilityToClinicUseCase {

--- a/src/main/java/com/medspace/application/usecase/clinicAvailability/AssignAvailabilityToClinicUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicAvailability/AssignAvailabilityToClinicUseCase.java
@@ -1,16 +1,27 @@
 package com.medspace.application.usecase.clinicAvailability;
 
 import com.medspace.application.service.ClinicAvailabilityService;
+import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.ClinicAvailability;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class AssignAvailabilityToClinicUseCase {
     @Inject
     ClinicAvailabilityService clinicAvailabilityService;
+    @Inject
+    ClinicService clinicService;
 
-    public ClinicAvailability execute(Long clinicAvailabilityId, Long clinicId) {
+    @Transactional
+    public ClinicAvailability execute(Long clinicAvailabilityId, Long clinicId, Long userId) {
+        Boolean isOwner = clinicService.validateClinicOwnership(clinicId, userId);
+        if (!isOwner) {
+            throw new ForbiddenException("Assign unauthorized");
+        }
+
         return clinicAvailabilityService.assignAvailabilityToClinic(clinicAvailabilityId, clinicId);
     }
 }

--- a/src/main/java/com/medspace/application/usecase/clinicAvailability/DeleteClinicAvailabilityByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicAvailability/DeleteClinicAvailabilityByIdUseCase.java
@@ -1,15 +1,30 @@
 package com.medspace.application.usecase.clinicAvailability;
 
 import com.medspace.application.service.ClinicAvailabilityService;
+import com.medspace.application.service.ClinicService;
+import com.medspace.domain.model.ClinicAvailability;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class DeleteClinicAvailabilityByIdUseCase {
     @Inject
     ClinicAvailabilityService clinicAvailabilityService;
+    @Inject
+    ClinicService clinicService;
 
-    public void execute(Long id) {
-        clinicAvailabilityService.deleteAvailabilityById(id);
+    @Transactional
+    public void execute(Long availabilityId, Long userId) {
+        ClinicAvailability clinicAvailability =
+                clinicAvailabilityService.getAvailabilityById(availabilityId);
+        Long clinicId = clinicAvailability != null ? clinicAvailability.getClinic().getId() : null;
+        Boolean isOwner = clinicService.validateClinicOwnership(clinicId, userId);
+        if (!isOwner) {
+            throw new ForbiddenException("Delete unauthorized");
+        }
+
+        clinicAvailabilityService.deleteAvailabilityById(availabilityId);
     }
 }

--- a/src/main/java/com/medspace/application/usecase/clinicAvailability/DeleteClinicAvailabilityByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicAvailability/DeleteClinicAvailabilityByIdUseCase.java
@@ -3,10 +3,10 @@ package com.medspace.application.usecase.clinicAvailability;
 import com.medspace.application.service.ClinicAvailabilityService;
 import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.ClinicAvailability;
+import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class DeleteClinicAvailabilityByIdUseCase {

--- a/src/main/java/com/medspace/application/usecase/clinicAvailability/UpdateClinicAvailabilityUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicAvailability/UpdateClinicAvailabilityUseCase.java
@@ -3,10 +3,10 @@ package com.medspace.application.usecase.clinicAvailability;
 import com.medspace.application.service.ClinicAvailabilityService;
 import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.ClinicAvailability;
+import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class UpdateClinicAvailabilityUseCase {

--- a/src/main/java/com/medspace/application/usecase/clinicAvailability/UpdateClinicAvailabilityUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicAvailability/UpdateClinicAvailabilityUseCase.java
@@ -1,16 +1,30 @@
 package com.medspace.application.usecase.clinicAvailability;
 
 import com.medspace.application.service.ClinicAvailabilityService;
+import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.ClinicAvailability;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class UpdateClinicAvailabilityUseCase {
     @Inject
     ClinicAvailabilityService clinicAvailabilityService;
+    @Inject
+    ClinicService clinicService;
 
-    public ClinicAvailability execute(Long id, ClinicAvailability clinicAvailability) {
+    @Transactional
+    public ClinicAvailability execute(Long id, ClinicAvailability clinicAvailability, Long userId) {
+        ClinicAvailability existingAvailability = clinicAvailabilityService.getAvailabilityById(id);
+        Long clinicId =
+                existingAvailability != null ? existingAvailability.getClinic().getId() : null;
+        Boolean isOwner = clinicService.validateClinicOwnership(clinicId, userId);
+        if (!isOwner) {
+            throw new ForbiddenException("Update unauthorized");
+        }
+
         return clinicAvailabilityService.updateAvailabilityById(id, clinicAvailability);
     }
 }

--- a/src/main/java/com/medspace/application/usecase/clinicEquipment/AssignEquipmentToClinicUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicEquipment/AssignEquipmentToClinicUseCase.java
@@ -1,16 +1,27 @@
 package com.medspace.application.usecase.clinicEquipment;
 
 import com.medspace.application.service.ClinicEquipmentService;
+import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.ClinicEquipment;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class AssignEquipmentToClinicUseCase {
     @Inject
     ClinicEquipmentService clinicEquipmentService;
+    @Inject
+    ClinicService clinicService;
 
-    public ClinicEquipment execute(Long clinicEquipmentId, Long clinicId) {
+    @Transactional
+    public ClinicEquipment execute(Long clinicEquipmentId, Long clinicId, Long userId) {
+        Boolean isOwner = clinicService.validateClinicOwnership(clinicId, userId);
+        if (!isOwner) {
+            throw new ForbiddenException("Assign unauthorized");
+        }
+
         return clinicEquipmentService.assignEquipmentToClinic(clinicEquipmentId, clinicId);
     }
 }

--- a/src/main/java/com/medspace/application/usecase/clinicEquipment/AssignEquipmentToClinicUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicEquipment/AssignEquipmentToClinicUseCase.java
@@ -3,10 +3,10 @@ package com.medspace.application.usecase.clinicEquipment;
 import com.medspace.application.service.ClinicEquipmentService;
 import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.ClinicEquipment;
+import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class AssignEquipmentToClinicUseCase {

--- a/src/main/java/com/medspace/application/usecase/clinicEquipment/DeleteClinicEquipmentByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicEquipment/DeleteClinicEquipmentByIdUseCase.java
@@ -1,15 +1,29 @@
 package com.medspace.application.usecase.clinicEquipment;
 
 import com.medspace.application.service.ClinicEquipmentService;
+import com.medspace.application.service.ClinicService;
+import com.medspace.domain.model.ClinicEquipment;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class DeleteClinicEquipmentByIdUseCase {
     @Inject
     ClinicEquipmentService clinicEquipmentService;
+    @Inject
+    ClinicService clinicService;
 
-    public void execute(Long id) {
+    @Transactional
+    public void execute(Long id, Long userId) {
+        ClinicEquipment clinicEquipment = clinicEquipmentService.getEquipmentById(id);
+        Long clinicId = clinicEquipment != null ? clinicEquipment.getClinic().getId() : null;
+        Boolean isOwner = clinicService.validateClinicOwnership(clinicId, userId);
+        if (!isOwner) {
+            throw new ForbiddenException("Delete unauthorized");
+        }
+
         clinicEquipmentService.deleteEquipmentById(id);
     }
 }

--- a/src/main/java/com/medspace/application/usecase/clinicEquipment/DeleteClinicEquipmentByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicEquipment/DeleteClinicEquipmentByIdUseCase.java
@@ -3,10 +3,10 @@ package com.medspace.application.usecase.clinicEquipment;
 import com.medspace.application.service.ClinicEquipmentService;
 import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.ClinicEquipment;
+import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class DeleteClinicEquipmentByIdUseCase {

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/AssignPhotoToClinicUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/AssignPhotoToClinicUseCase.java
@@ -3,10 +3,10 @@ package com.medspace.application.usecase.clinicPhoto;
 import com.medspace.application.service.ClinicPhotoService;
 import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.ClinicPhoto;
+import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class AssignPhotoToClinicUseCase {

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/AssignPhotoToClinicUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/AssignPhotoToClinicUseCase.java
@@ -1,16 +1,27 @@
 package com.medspace.application.usecase.clinicPhoto;
 
 import com.medspace.application.service.ClinicPhotoService;
+import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.ClinicPhoto;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class AssignPhotoToClinicUseCase {
     @Inject
     ClinicPhotoService clinicPhotoService;
+    @Inject
+    ClinicService clinicService;
 
-    public ClinicPhoto execute(Long clinicPhotoId, Long clinicId) {
+    @Transactional
+    public ClinicPhoto execute(Long clinicPhotoId, Long clinicId, Long userId) {
+        Boolean isOwner = clinicService.validateClinicOwnership(clinicId, userId);
+        if (!isOwner) {
+            throw new ForbiddenException("Assign unauthorized");
+        }
+
         return clinicPhotoService.assignPhotoToClinic(clinicPhotoId, clinicId);
     }
 }

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/DeleteClinicPhotoByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/DeleteClinicPhotoByIdUseCase.java
@@ -1,15 +1,29 @@
 package com.medspace.application.usecase.clinicPhoto;
 
 import com.medspace.application.service.ClinicPhotoService;
+import com.medspace.application.service.ClinicService;
+import com.medspace.domain.model.ClinicPhoto;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class DeleteClinicPhotoByIdUseCase {
     @Inject
     ClinicPhotoService clinicPhotoService;
+    @Inject
+    ClinicService clinicService;
 
-    public void execute(Long id) {
-        clinicPhotoService.deletePhoto(id);
+    @Transactional
+    public void execute(Long photoId, Long userId) {
+        ClinicPhoto clinicPhoto = clinicPhotoService.getPhotoById(photoId);
+        Long clinicId = clinicPhoto != null ? clinicPhoto.getClinic().getId() : null;
+        Boolean isOwner = clinicService.validateClinicOwnership(clinicId, userId);
+        if (!isOwner) {
+            throw new ForbiddenException("Delete unauthorized");
+        }
+
+        clinicPhotoService.deletePhoto(photoId);
     }
 }

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/DeleteClinicPhotoByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/DeleteClinicPhotoByIdUseCase.java
@@ -3,10 +3,10 @@ package com.medspace.application.usecase.clinicPhoto;
 import com.medspace.application.service.ClinicPhotoService;
 import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.ClinicPhoto;
+import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class DeleteClinicPhotoByIdUseCase {

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/SetPhotoAsPrimaryClinicPhotoUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/SetPhotoAsPrimaryClinicPhotoUseCase.java
@@ -1,15 +1,27 @@
 package com.medspace.application.usecase.clinicPhoto;
 
 import com.medspace.application.service.ClinicPhotoService;
+import com.medspace.application.service.ClinicService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class SetPhotoAsPrimaryClinicPhotoUseCase {
     @Inject
     ClinicPhotoService clinicPhotoService;
+    @Inject
+    ClinicService clinicService;
 
-    public void execute(Long id) {
-        clinicPhotoService.setPhotoAsPrimary(id);
+    @Transactional
+    public void execute(Long photoId, Long clinicId, Long landlordId) {
+        Boolean isPhotoFromClinic = clinicPhotoService.validatePhotoOwnership(photoId, clinicId);
+        Boolean isClinicFromLandlord = clinicService.validateClinicOwnership(clinicId, landlordId);
+        if (!isPhotoFromClinic || !isClinicFromLandlord) {
+            throw new ForbiddenException("Update unauthorized");
+        }
+
+        clinicPhotoService.setPhotoAsPrimary(photoId);
     }
 }

--- a/src/main/java/com/medspace/application/usecase/clinicPhoto/SetPhotoAsPrimaryClinicPhotoUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinicPhoto/SetPhotoAsPrimaryClinicPhotoUseCase.java
@@ -2,10 +2,10 @@ package com.medspace.application.usecase.clinicPhoto;
 
 import com.medspace.application.service.ClinicPhotoService;
 import com.medspace.application.service.ClinicService;
+import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import jakarta.ws.rs.ForbiddenException;
 
 @ApplicationScoped
 public class SetPhotoAsPrimaryClinicPhotoUseCase {

--- a/src/main/java/com/medspace/domain/repository/ClinicAvailabilityRepository.java
+++ b/src/main/java/com/medspace/domain/repository/ClinicAvailabilityRepository.java
@@ -9,6 +9,8 @@ public interface ClinicAvailabilityRepository {
 
     public ClinicAvailability updateAvailability(Long id, ClinicAvailability clinicAvailability);
 
+    public ClinicAvailability getAvailabilityById(Long id);
+
     public void deleteAvailabilityById(Long id);
 
     public ClinicAvailability assignAvailabilityToClinic(Long clinicAvailabilityId, Long clinicId);

--- a/src/main/java/com/medspace/domain/repository/ClinicRepository.java
+++ b/src/main/java/com/medspace/domain/repository/ClinicRepository.java
@@ -11,6 +11,8 @@ public interface ClinicRepository {
 
     public Clinic getClinicById(Long id);
 
+    public List<Clinic> getClinicsByLandlordId(Long landlordId);
+
     public void deleteClinicById(Long id);
 
     public Clinic assignClinicToUser(Long clinicId, Long userId);

--- a/src/main/java/com/medspace/infrastructure/dto/CreateClinicDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/CreateClinicDTO.java
@@ -46,9 +46,6 @@ public class CreateClinicDTO {
     @NotBlank
     private String addressLatitude;
 
-    @NotNull
-    private Long userId;
-
     public Clinic toClinic() {
         Clinic clinic = new Clinic();
 

--- a/src/main/java/com/medspace/infrastructure/repository/ClinicAvailabilityRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/ClinicAvailabilityRepositoryImpl.java
@@ -89,4 +89,12 @@ public class ClinicAvailabilityRepositoryImpl implements ClinicAvailabilityRepos
 
         return clinicAvailabilities;
     }
+
+    public ClinicAvailability getAvailabilityById(Long id) {
+        ClinicAvailabilityEntity clinicAvailabilityEntity = findById(id);
+        if (clinicAvailabilityEntity == null) {
+            return null;
+        }
+        return ClinicAvailabilityMapper.toDomain(clinicAvailabilityEntity);
+    }
 }

--- a/src/main/java/com/medspace/infrastructure/repository/ClinicEquipmentRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/ClinicEquipmentRepositoryImpl.java
@@ -34,7 +34,7 @@ public class ClinicEquipmentRepositoryImpl
     public ClinicEquipment getEquipmentById(Long id) {
         ClinicEquipmentEntity clinicEquipmentEntity = findById(id);
         if (clinicEquipmentEntity == null) {
-            throw new NotFoundException("ClinicEquipment with id " + id + " not found");
+            return null;
         }
         return ClinicEquipmentMapper.toDomain(clinicEquipmentEntity);
     }

--- a/src/main/java/com/medspace/infrastructure/repository/ClinicPhotoRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/ClinicPhotoRepositoryImpl.java
@@ -33,7 +33,7 @@ public class ClinicPhotoRepositoryImpl
     public ClinicPhoto getPhotoById(Long id) {
         ClinicPhotoEntity clinicPhotoEntity = findById(id);
         if (clinicPhotoEntity == null) {
-            throw new NotFoundException("ClinicPhoto with id " + id + " not Found");
+            return null;
         }
         return ClinicPhotoMapper.toDomain(clinicPhotoEntity);
     }

--- a/src/main/java/com/medspace/infrastructure/repository/ClinicRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/ClinicRepositoryImpl.java
@@ -42,6 +42,18 @@ public class ClinicRepositoryImpl
     }
 
     @Override
+    public List<Clinic> getClinicsByLandlordId(Long landlordId) {
+        List<ClinicEntity> clinicEntities = find("landlord.id", landlordId).list();
+        List<Clinic> clinics = new ArrayList<>();
+
+        for (ClinicEntity clinicEntity : clinicEntities) {
+            clinics.add(ClinicMapper.toDomain(clinicEntity));
+        }
+
+        return clinics;
+    }
+
+    @Override
     public Clinic getClinicById(Long id) {
         ClinicEntity clinicEntity = findById(id);
         if (clinicEntity == null) {

--- a/src/main/java/com/medspace/infrastructure/rest/filters/AnalystFilter.java
+++ b/src/main/java/com/medspace/infrastructure/rest/filters/AnalystFilter.java
@@ -28,6 +28,7 @@ public class AnalystFilter implements ContainerRequestFilter {
         if (requestContext.getUser() == null) {
             ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED)
                     .entity(ResponseDTO.error("User not authenticated")).build());
+            return;
         }
 
 

--- a/src/main/java/com/medspace/infrastructure/rest/filters/LandlordFilter.java
+++ b/src/main/java/com/medspace/infrastructure/rest/filters/LandlordFilter.java
@@ -27,6 +27,7 @@ public class LandlordFilter implements ContainerRequestFilter {
         if (requestContext.getUser() == null) {
             ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED)
                     .entity(ResponseDTO.error("User not authenticated")).build());
+            return;
         }
 
 

--- a/src/main/java/com/medspace/infrastructure/rest/filters/TenantFilter.java
+++ b/src/main/java/com/medspace/infrastructure/rest/filters/TenantFilter.java
@@ -28,6 +28,7 @@ public class TenantFilter implements ContainerRequestFilter {
         if (requestContext.getUser() == null) {
             ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED)
                     .entity(ResponseDTO.error("User not authenticated")).build());
+            return;
         }
 
 


### PR DESCRIPTION
## Summary
This PR modifies all the Clinic resources to be aware of the authentication context provided by Firebase. It adds validation to verify that the requester is logged in as the appropriate type of user, and that it is owner of the resources they want to modify.

## Context
Before this PR, any user could make changes to the clinic related entities without providing credentials. The PR adds security by ensuring authentication and authorization. 
The PR extends on the changes done by PR #10 

## Changes
Added corresponding authorization filters and injected request context to:
- `ClinicController`
- `ClinicEquipmentController`
- `ClinicPhotoController`
- `ClinicAvailabilityController`

Updated the Assign, Delete, and Update use cases of the following resources to ensure authorization
- `Clinic`
- `ClinicPhoto`
- `ClinicEquipment`
- `ClinicAvailability`

Added a new `ClinicController` endpoint (GET clinics/landlord) to get all the clinics associated to the currently logged in user

## Test Plan
Tested manually the controllers to verify that authentication works and the behavior for authenticated users is the same as before:

**GET /clinics**
With auth:
<img width="905" alt="Captura de pantalla 2025-04-27 a la(s) 9 28 48 a m" src="https://github.com/user-attachments/assets/7f3ba621-9017-47cf-a2cd-480baedfd999" />

No auth:
<img width="850" alt="Captura de pantalla 2025-04-27 a la(s) 9 28 15 a m" src="https://github.com/user-attachments/assets/bae590e9-d6d5-419b-9367-d941f2d9329d" />

**GET /clinics/landlord**
<img width="916" alt="Captura de pantalla 2025-04-27 a la(s) 9 29 36 a m" src="https://github.com/user-attachments/assets/931310b2-a475-4980-8bcc-64ff1d2912a9" />

**DELETE /clinics/{id}**
With auth:
<img width="817" alt="Captura de pantalla 2025-04-27 a la(s) 9 31 27 a m" src="https://github.com/user-attachments/assets/93764b40-04f2-46d3-b1d0-c29f9b96e8c4" />

No auth:
<img width="850" alt="Captura de pantalla 2025-04-27 a la(s) 9 31 49 a m" src="https://github.com/user-attachments/assets/b6027af6-4dfa-4aa7-af58-0744f0b3ad33" />

**PUT /clinics/{id}/primary-photo**
With auth:
<img width="843" alt="Captura de pantalla 2025-04-27 a la(s) 9 35 39 a m" src="https://github.com/user-attachments/assets/ce4c5ae4-3711-4e67-a6fa-99699b5ab6d6" />

No auth:
<img width="822" alt="Captura de pantalla 2025-04-27 a la(s) 9 35 09 a m" src="https://github.com/user-attachments/assets/7f434576-f1c8-4a87-95e8-e403bc3d215a" />

**DELETE /clinic-equipments/{id}**
With auth:
<img width="854" alt="Captura de pantalla 2025-04-27 a la(s) 9 37 44 a m" src="https://github.com/user-attachments/assets/3064c68a-f7a6-4869-be0c-9cff0dfa2e52" />

No auth:
<img width="826" alt="Captura de pantalla 2025-04-27 a la(s) 9 36 51 a m" src="https://github.com/user-attachments/assets/cc28c336-9cbf-403d-b69c-360bb48536d1" />
