### PR TITLE
feature(notifications): implement complete notification system with r…

### DIFF
--- a/src/main/java/com/medspace/application/service/NotificationService.java
+++ b/src/main/java/com/medspace/application/service/NotificationService.java
@@ -1,0 +1,41 @@
+package com.medspace.application.service;
+
+import com.medspace.domain.model.Notification;
+import com.medspace.domain.repository.NotificationRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Instant;
+import java.util.List;
+
+@ApplicationScoped
+public class NotificationService {
+    @Inject
+    NotificationRepository notificationRepository;
+
+    public Notification createNotification(Notification notification) {
+        notification.setCreatedAt(Instant.now());
+        notification = notificationRepository.save(notification);
+        return notification;
+    }
+
+    public Notification getNotificationById(Long id) {
+        return notificationRepository.getNotificationById(id);
+    }
+
+    public Notification assignNotificationToUser(Long notificationId, Long userId) {
+        return notificationRepository.assignNotificationToUser(notificationId, userId);
+    }
+
+    public List<Notification> getNotificationsByUserId(Long userId) {
+        return notificationRepository.getNotificationsByUserId(userId);
+    }
+
+    public void deleteNotification(Long id) {
+        notificationRepository.deleteNotificationById(id);
+    }
+
+    public void markAsRead(Long id) {
+        notificationRepository.markAsRead(id);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/notification/AssignNotificationToUserUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/notification/AssignNotificationToUserUseCase.java
@@ -1,0 +1,16 @@
+package com.medspace.application.usecase.notification;
+
+import com.medspace.application.service.NotificationService;
+import com.medspace.domain.model.Notification;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class AssignNotificationToUserUseCase {
+    @Inject
+    NotificationService notificationService;
+
+    public Notification execute(Long notificationId, Long userId) {
+        return notificationService.assignNotificationToUser(notificationId, userId);
+    }
+} 

--- a/src/main/java/com/medspace/application/usecase/notification/CreateNotificationUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/notification/CreateNotificationUseCase.java
@@ -1,0 +1,16 @@
+package com.medspace.application.usecase.notification;
+
+import com.medspace.application.service.NotificationService;
+import com.medspace.domain.model.Notification;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class CreateNotificationUseCase {
+    @Inject
+    NotificationService notificationService;
+
+    public Notification execute(Notification notification) {
+        return notificationService.createNotification(notification);
+    }
+} 

--- a/src/main/java/com/medspace/application/usecase/notification/DeleteNotificationUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/notification/DeleteNotificationUseCase.java
@@ -1,0 +1,15 @@
+package com.medspace.application.usecase.notification;
+
+import com.medspace.application.service.NotificationService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class DeleteNotificationUseCase {
+    @Inject
+    NotificationService notificationService;
+
+    public void execute(Long id) {
+        notificationService.deleteNotification(id);
+    }
+} 

--- a/src/main/java/com/medspace/application/usecase/notification/GetNotificationByIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/notification/GetNotificationByIdUseCase.java
@@ -1,0 +1,16 @@
+package com.medspace.application.usecase.notification;
+
+import com.medspace.application.service.NotificationService;
+import com.medspace.domain.model.Notification;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class GetNotificationByIdUseCase {
+    @Inject
+    NotificationService notificationService;
+
+    public Notification execute(Long id) {
+        return notificationService.getNotificationById(id);
+    }
+} 

--- a/src/main/java/com/medspace/application/usecase/notification/GetUserNotificationsUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/notification/GetUserNotificationsUseCase.java
@@ -1,0 +1,17 @@
+package com.medspace.application.usecase.notification;
+
+import com.medspace.application.service.NotificationService;
+import com.medspace.domain.model.Notification;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.List;
+
+@ApplicationScoped
+public class GetUserNotificationsUseCase {
+    @Inject
+    NotificationService notificationService;
+
+    public List<Notification> execute(Long userId) {
+        return notificationService.getNotificationsByUserId(userId);
+    }
+} 

--- a/src/main/java/com/medspace/application/usecase/notification/MarkNotificationAsReadUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/notification/MarkNotificationAsReadUseCase.java
@@ -1,0 +1,27 @@
+package com.medspace.application.usecase.notification;
+
+import com.medspace.application.service.NotificationService;
+import com.medspace.domain.model.Notification;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.NotFoundException;
+
+@ApplicationScoped
+public class MarkNotificationAsReadUseCase {
+    @Inject
+    NotificationService notificationService;
+
+    public void execute(Long id, Long userId) {
+        Notification notification = notificationService.getNotificationById(id);
+        if (notification == null) {
+            throw new NotFoundException("Notification not found");
+        }
+
+        if (!notification.getUser().getId().equals(userId)) {
+            throw new ForbiddenException("You don't have permission to mark this notification as read");
+        }
+
+        notificationService.markAsRead(id);
+    }
+} 

--- a/src/main/java/com/medspace/domain/model/Notification.java
+++ b/src/main/java/com/medspace/domain/model/Notification.java
@@ -1,0 +1,21 @@
+package com.medspace.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class Notification {
+
+    private Long id;
+    private User user;
+    private String message;
+    private Instant createdAt;
+    private Boolean isRead;
+} 

--- a/src/main/java/com/medspace/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/medspace/domain/repository/NotificationRepository.java
@@ -1,0 +1,13 @@
+package com.medspace.domain.repository;
+
+import com.medspace.domain.model.Notification;
+import java.util.List;
+
+public interface NotificationRepository {
+    public Notification save(Notification notification);
+    public Notification getNotificationById(Long id);
+    public Notification assignNotificationToUser(Long notificationId, Long userId);
+    public List<Notification> getNotificationsByUserId(Long userId);
+    public void deleteNotificationById(Long id);
+    public void markAsRead(Long id);
+} 

--- a/src/main/java/com/medspace/infrastructure/dto/CreateNotificationDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/CreateNotificationDTO.java
@@ -1,0 +1,25 @@
+package com.medspace.infrastructure.dto;
+
+import com.medspace.domain.model.Notification;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateNotificationDTO {
+    @NotBlank(message = "Message is required")
+    @Size(max = 500, message = "Message cannot exceed 500 characters")
+    private String message;
+
+    public Notification toNotification() {
+        Notification notification = new Notification();
+        notification.setMessage(message);
+        return notification;
+    }
+} 

--- a/src/main/java/com/medspace/infrastructure/dto/GetNotificationDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/GetNotificationDTO.java
@@ -1,0 +1,27 @@
+package com.medspace.infrastructure.dto;
+
+import com.medspace.domain.model.Notification;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetNotificationDTO {
+    private Long id;
+    private Long userId;
+    private String message;
+    private String createdAt;
+
+    public GetNotificationDTO(Notification notification) {
+        if (notification != null) {
+            this.id = notification.getId();
+            this.userId = notification.getUser() != null ? notification.getUser().getId() : null;
+            this.message = notification.getMessage();
+            this.createdAt = notification.getCreatedAt() != null ? notification.getCreatedAt().toString() : null;
+        }
+    }
+} 

--- a/src/main/java/com/medspace/infrastructure/entity/NotificationEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/NotificationEntity.java
@@ -1,0 +1,33 @@
+package com.medspace.infrastructure.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.time.Instant;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "message", nullable = false)
+    private String message;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+} 

--- a/src/main/java/com/medspace/infrastructure/mapper/NotificationMapper.java
+++ b/src/main/java/com/medspace/infrastructure/mapper/NotificationMapper.java
@@ -1,0 +1,36 @@
+package com.medspace.infrastructure.mapper;
+
+import com.medspace.domain.model.Notification;
+import com.medspace.infrastructure.entity.NotificationEntity;
+
+public class NotificationMapper {
+    public static Notification toDomain(NotificationEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        Notification notification = new Notification();
+        notification.setId(entity.getId());
+        notification.setMessage(entity.getMessage());
+        notification.setCreatedAt(entity.getCreatedAt());
+        notification.setIsRead(entity.getIsRead());
+        notification.setUser(UserMapper.toDomain(entity.getUser()));
+
+        return notification;
+    }
+
+    public static NotificationEntity toEntity(Notification notification) {
+        if (notification == null) {
+            return null;
+        }
+
+        NotificationEntity entity = new NotificationEntity();
+        entity.setId(notification.getId());
+        entity.setMessage(notification.getMessage());
+        entity.setCreatedAt(notification.getCreatedAt());
+        entity.setIsRead(notification.getIsRead());
+        entity.setUser(UserMapper.toEntity(notification.getUser()));
+
+        return entity;
+    }
+} 

--- a/src/main/java/com/medspace/infrastructure/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/NotificationRepositoryImpl.java
@@ -1,0 +1,95 @@
+package com.medspace.infrastructure.repository;
+
+import com.medspace.domain.model.Notification;
+import com.medspace.domain.repository.NotificationRepository;
+import com.medspace.infrastructure.entity.NotificationEntity;
+import com.medspace.infrastructure.entity.UserEntity;
+import com.medspace.infrastructure.mapper.NotificationMapper;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.NotFoundException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ApplicationScoped
+public class NotificationRepositoryImpl implements NotificationRepository, PanacheRepositoryBase<NotificationEntity, Long> {
+    @Inject
+    UserRepositoryImpl userRepository;
+
+    @Transactional
+    @Override
+    public Notification save(Notification notification) {
+        NotificationEntity notificationEntity = NotificationMapper.toEntity(notification);
+        persist(notificationEntity);
+        notification = NotificationMapper.toDomain(notificationEntity);
+        return notification;
+    }
+
+    @Override
+    public Notification getNotificationById(Long id) {
+        NotificationEntity notificationEntity = findById(id);
+        if (notificationEntity == null) {
+            throw new NotFoundException("Notification with id " + id + " not found");
+        }
+        return NotificationMapper.toDomain(notificationEntity);
+    }
+
+    @Override
+    @Transactional
+    public Notification assignNotificationToUser(Long notificationId, Long userId) {
+        NotificationEntity notificationEntity = findById(notificationId);
+        if (notificationEntity == null) {
+            throw new NotFoundException("Notification with id " + notificationId + " not found");
+        }
+
+        UserEntity userEntity = userRepository.findById(userId);
+        if (userEntity == null) {
+            throw new NotFoundException("User with id " + userId + " not found");
+        }
+
+        notificationEntity.setUser(userEntity);
+        persist(notificationEntity);
+        return NotificationMapper.toDomain(notificationEntity);
+    }
+
+    @Override
+    public List<Notification> getNotificationsByUserId(Long userId) {
+        UserEntity userEntity = userRepository.findById(userId);
+        if (userEntity == null) {
+            throw new NotFoundException("User with id " + userId + " not found");
+        }
+
+        List<NotificationEntity> notificationEntities = find("user", userEntity).list();
+        List<Notification> notifications = new ArrayList<>();
+        for (NotificationEntity notificationEntity : notificationEntities) {
+            notifications.add(NotificationMapper.toDomain(notificationEntity));
+        }
+        return notifications;
+    }
+
+    @Override
+    @Transactional
+    public void deleteNotificationById(Long id) {
+        NotificationEntity notificationEntity = findById(id);
+        if (notificationEntity != null) {
+            delete(notificationEntity);
+        } else {
+            throw new NotFoundException("Notification with id " + id + " not found");
+        }
+    }
+
+    @Override
+    @Transactional
+    public void markAsRead(Long id) {
+        NotificationEntity notificationEntity = findById(id);
+        if (notificationEntity != null) {
+            notificationEntity.setIsRead(true);
+            persist(notificationEntity);
+        } else {
+            throw new NotFoundException("Notification with id " + id + " not found");
+        }
+    }
+} 

--- a/src/main/java/com/medspace/infrastructure/rest/NotificationController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/NotificationController.java
@@ -38,8 +38,10 @@ public class NotificationController {
             List<Notification> notifications = getUserNotificationsUseCase.execute(loggedUser.getId());
             return Response.ok(ResponseDTO.success("Notifications fetched", notifications)).build();
         } catch (Exception e) {
+            // Log the exception details for internal debugging
+            Logger.getLogger(NotificationController.class.getName()).severe("Error fetching notifications: " + e.getMessage());
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                .entity(ResponseDTO.error(e.getMessage()))
+                .entity(ResponseDTO.error("An unexpected error occurred. Please try again later."))
                 .build();
         }
     }

--- a/src/main/java/com/medspace/infrastructure/rest/NotificationController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/NotificationController.java
@@ -1,0 +1,69 @@
+package com.medspace.infrastructure.rest;
+
+import com.medspace.application.usecase.notification.*;
+import com.medspace.domain.model.Notification;
+import com.medspace.domain.model.User;
+import com.medspace.infrastructure.dto.*;
+import com.medspace.infrastructure.rest.annotations.UserOnly;
+import com.medspace.infrastructure.rest.context.RequestContext;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+
+@ApplicationScoped
+@Path("/notifications")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@UserOnly
+public class NotificationController {
+
+    @Inject
+    GetUserNotificationsUseCase getUserNotificationsUseCase;
+
+    @Inject
+    MarkNotificationAsReadUseCase markNotificationAsReadUseCase;
+
+    @Inject
+    RequestContext requestContext;
+
+    @GET
+    public Response getNotifications() {
+        try {
+            User loggedUser = requestContext.getUser();
+            List<Notification> notifications = getUserNotificationsUseCase.execute(loggedUser.getId());
+            return Response.ok(ResponseDTO.success("Notifications fetched", notifications)).build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity(ResponseDTO.error(e.getMessage()))
+                .build();
+        }
+    }
+
+    @PUT
+    @Path("/{id}/read")
+    @Transactional
+    public Response markAsRead(@PathParam("id") Long id) {
+        try {
+            User loggedUser = requestContext.getUser();
+            markNotificationAsReadUseCase.execute(id, loggedUser.getId());
+            return Response.ok(ResponseDTO.success("Notification marked as read")).build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND)
+                .entity(ResponseDTO.error(e.getMessage()))
+                .build();
+        } catch (ForbiddenException e) {
+            return Response.status(Response.Status.FORBIDDEN)
+                .entity(ResponseDTO.error(e.getMessage()))
+                .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity(ResponseDTO.error(e.getMessage()))
+                .build();
+        }
+    }
+} 


### PR DESCRIPTION
## Summary

This PR modifies all the **Notification** resources to be aware of the authentication context provided by Firebase. It adds validation to ensure that the requester is authenticated and is the owner of the notifications they want to access or modify.

### Context

Before this PR, didn't exist notifications entity implementations and any user could access or modify notification-related entities without providing credentials. This PR adds security by enforcing authentication and authorization for all notification operations.


### Changes

- Added corresponding authorization filters and injected request context to:
  - `NotificationController`
- Updated the relevant use cases to ensure authorization and ownership validation:
  - `MarkNotificationAsReadUseCase`
  - `GetUserNotificationsUseCase`
- Ensured that only the owner of a notification can mark it as read or view their notifications.

### Test Plan

- Manually tested the controller to verify that authentication works and the behavior for authenticated users is the same as before:
  - `GET /notifications` (returns only notifications for the logged-in user)
  
<img width="1462" alt="Screenshot 2025-04-27 at 4 40 37 p m" src="https://github.com/user-attachments/assets/59c157ca-4a58-4b7e-b853-d161569df5b7" />

<img width="1393" alt="Screenshot 2025-04-27 at 6 45 39 p m" src="https://github.com/user-attachments/assets/5b75a72b-1c6f-4547-9b2d-bc804ff29dfe" />
<img width="1379" alt="Screenshot 2025-04-27 at 6 52 37 p m" src="https://github.com/user-attachments/assets/db9e9974-6dae-42ec-9bae-3aa9b96d926a" />



  - `PUT /notifications/{id}/read` (only allows marking own notifications as read)
  
<img width="1374" alt="Screenshot 2025-04-27 at 6 54 48 p m" src="https://github.com/user-attachments/assets/8791838c-760f-4225-9431-76eb80409085" />
<img width="1381" alt="Screenshot 2025-04-27 at 6 54 58 p m" src="https://github.com/user-attachments/assets/6e7cf1f5-182c-4af3-b9ea-6e61783b3e36" />

- Verified that unauthenticated or unauthorized users cannot access or modify notifications.