### PR TITLE
Refactor: Add authentication to Tenant Favorite Clinic resources

### DIFF
--- a/src/main/java/com/medspace/application/service/TenantFavoriteClinicService.java
+++ b/src/main/java/com/medspace/application/service/TenantFavoriteClinicService.java
@@ -1,5 +1,6 @@
 package com.medspace.application.service;
 
+import com.medspace.domain.model.Review;
 import com.medspace.domain.model.TenantFavoriteClinic;
 import com.medspace.domain.repository.TenantFavoriteClinicRepository;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -14,7 +15,6 @@ public class TenantFavoriteClinicService {
     TenantFavoriteClinicRepository tenantFavoriteClinicRepository;
 
     public TenantFavoriteClinic createTenantFavoriteClinic(TenantFavoriteClinic favoriteClinic) {
-        favoriteClinic.setCreatedAt(Instant.now());
         return tenantFavoriteClinicRepository.createTenantFavoriteClinic(favoriteClinic);
     }
 
@@ -44,6 +44,18 @@ public class TenantFavoriteClinicService {
 
     public TenantFavoriteClinic assignToClinic(Long favoriteClinicId, Long clinicId) {
         return tenantFavoriteClinicRepository.assignToClinic(favoriteClinicId, clinicId);
+    }
+
+    public Boolean validateFavoriteClinicOwnership(Long favoriteId, Long tenantId) {
+        if (favoriteId == null || tenantId == null) {
+            return false;
+        }
+        TenantFavoriteClinic favorite =
+                tenantFavoriteClinicRepository.getFavoriteClinicById(favoriteId);
+        if (favorite == null || favorite.getTenant() == null) {
+            return false;
+        }
+        return favorite.getTenant().getId().equals(tenantId);
     }
 
 

--- a/src/main/java/com/medspace/infrastructure/dto/CreateTenantFavoriteClinicDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/CreateTenantFavoriteClinicDTO.java
@@ -2,6 +2,7 @@ package com.medspace.infrastructure.dto;
 
 import com.medspace.domain.model.TenantFavoriteClinic;
 import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,8 +14,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class CreateTenantFavoriteClinicDTO {
 
-    @NotNull
-    private Long tenantId;
+
 
     @NotNull
     private Long clinicId;

--- a/src/main/java/com/medspace/infrastructure/repository/TenantFavoriteClinicRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/TenantFavoriteClinicRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.medspace.domain.repository.TenantFavoriteClinicRepository;
 import com.medspace.infrastructure.entity.ClinicEntity;
 import com.medspace.infrastructure.entity.TenantFavoriteClinicEntity;
 import com.medspace.infrastructure.entity.UserEntity;
+import java.time.Instant;
 import com.medspace.infrastructure.mapper.TenantFavoriteClinicMapper;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -29,7 +30,10 @@ public class TenantFavoriteClinicRepositoryImpl implements TenantFavoriteClinicR
     @Transactional
     @Override
     public TenantFavoriteClinic createTenantFavoriteClinic(
-            TenantFavoriteClinic tenantFavoriteClinic) {
+        TenantFavoriteClinic tenantFavoriteClinic) {
+        if (tenantFavoriteClinic.getCreatedAt() == null) {
+            tenantFavoriteClinic.setCreatedAt(Instant.now());
+        }
         TenantFavoriteClinicEntity tenantFavoriteClinicEntity =
                 TenantFavoriteClinicMapper.toEntity(tenantFavoriteClinic);
         persist(tenantFavoriteClinicEntity);


### PR DESCRIPTION
### Summary
This PR modifies all the Tenant Favorite Clinic resources to be aware of the authentication context provided by Firebase. It adds validation to verify that the requester is logged in as the appropriate type of user, and that it is owner of the resources they want to modify.

### Context
Before this PR, any user could make changes to the tenant favorite clinic related entities without providing credentials. The PR adds security by ensuring authentication and authorization.


### Changes
Added corresponding authorization filters and injected request context to:

TenantFavoriteClinicController

Updated the Get, Delete, and Create use cases of the following resources to ensure authorization

TenantFavoriteClinic

Added a new TenantFavoriteClinicController endpoint (GET /me) to get all the favorite clinics associated to the currently logged in user

### Test Plan
**GET users/favorite-clinic/me**
<img width="1384" alt="Screenshot 2025-05-01 at 9 52 17 p m" src="https://github.com/user-attachments/assets/45658b11-9c81-4a9c-b53c-9cd8b13e3e04" />
Without authentication
<img width="1389" alt="Screenshot 2025-05-01 at 9 53 16 p m" src="https://github.com/user-attachments/assets/bd7e1545-f489-450d-ac38-26101f795b70" />
**POST /favorite-clinic**
<img width="1388" alt="Screenshot 2025-05-01 at 9 53 33 p m" src="https://github.com/user-attachments/assets/77d1e679-356a-4792-9bdf-a14729c42aa4" />
Without authentication
<img width="1391" alt="Screenshot 2025-05-01 at 9 54 01 p m" src="https://github.com/user-attachments/assets/f9fed65f-dbfc-4e46-bd08-6580c99bd02d" />
**DELETE /favorite-clinic**
<img width="1394" alt="Screenshot 2025-05-01 at 9 54 18 p m" src="https://github.com/user-attachments/assets/a0c0e7d1-4a21-4bc5-baaf-13664c12e6cd" />
Without authetication
<img width="1385" alt="Screenshot 2025-05-01 at 9 54 44 p m" src="https://github.com/user-attachments/assets/eb6c9e51-8c16-4477-8672-77c76afb0102" />



