### PR TITLE
Feature: add query by landlord id for rent request entity

### DIFF
--- a/src/main/java/com/medspace/application/usecase/rentRequest/GetRentRequestsByLandlordIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/rentRequest/GetRentRequestsByLandlordIdUseCase.java
@@ -1,8 +1,13 @@
 package com.medspace.application.usecase.rentRequest;
 
 import java.util.List;
+import com.medspace.application.service.ClinicService;
+import com.medspace.application.service.UserService;
+import com.medspace.domain.model.Clinic;
 import com.medspace.domain.model.RentRequest;
+import com.medspace.domain.model.User;
 import com.medspace.domain.repository.RentRequestRepository;
+import com.medspace.infrastructure.dto.rentRequest.GetRentRequestPreviewDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -10,9 +15,18 @@ import jakarta.inject.Inject;
 public class GetRentRequestsByLandlordIdUseCase {
     @Inject
     RentRequestRepository rentRequestRepository;
+    @Inject
+    UserService userService;
+    @Inject
+    ClinicService clinicService;
 
-    public List<RentRequest> execute(Long landlordId) {
-        return rentRequestRepository.findByLandlordId(landlordId);
+    public List<GetRentRequestPreviewDTO> execute(Long landlordId) {
+        List<RentRequest> rentRequests = rentRequestRepository.findByLandlordId(landlordId);
+
+        return rentRequests.stream().map(rentRequest -> {
+            User tenant = userService.getUserById(rentRequest.getTenant().getId());
+            Clinic clinic = clinicService.getClinicById(rentRequest.getClinic().getId());
+            return new GetRentRequestPreviewDTO(rentRequest, clinic, tenant);
+        }).toList();
     }
-
 }

--- a/src/main/java/com/medspace/application/usecase/rentRequest/GetRentRequestsByLandlordIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/rentRequest/GetRentRequestsByLandlordIdUseCase.java
@@ -8,6 +8,7 @@ import com.medspace.domain.model.RentRequest;
 import com.medspace.domain.model.User;
 import com.medspace.domain.repository.RentRequestRepository;
 import com.medspace.infrastructure.dto.rentRequest.GetRentRequestPreviewDTO;
+import com.medspace.infrastructure.dto.rentRequest.RentRequestQueryFilterDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -20,8 +21,8 @@ public class GetRentRequestsByLandlordIdUseCase {
     @Inject
     ClinicService clinicService;
 
-    public List<GetRentRequestPreviewDTO> execute(Long landlordId) {
-        List<RentRequest> rentRequests = rentRequestRepository.findByLandlordId(landlordId);
+    public List<GetRentRequestPreviewDTO> execute(RentRequestQueryFilterDTO filterDTO) {
+        List<RentRequest> rentRequests = rentRequestRepository.findByLandlordId(filterDTO);
 
         return rentRequests.stream().map(rentRequest -> {
             User tenant = userService.getUserById(rentRequest.getTenant().getId());

--- a/src/main/java/com/medspace/application/usecase/rentRequest/GetRentRequestsByLandlordIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/rentRequest/GetRentRequestsByLandlordIdUseCase.java
@@ -1,0 +1,18 @@
+package com.medspace.application.usecase.rentRequest;
+
+import java.util.List;
+import com.medspace.domain.model.RentRequest;
+import com.medspace.domain.repository.RentRequestRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class GetRentRequestsByLandlordIdUseCase {
+    @Inject
+    RentRequestRepository rentRequestRepository;
+
+    public List<RentRequest> execute(Long landlordId) {
+        return rentRequestRepository.findByLandlordId(landlordId);
+    }
+
+}

--- a/src/main/java/com/medspace/domain/model/RentRequest.java
+++ b/src/main/java/com/medspace/domain/model/RentRequest.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-
+import java.sql.Date;
 import java.time.Instant;
 
 
@@ -17,8 +17,8 @@ public class RentRequest {
     private User tenant;
     private Clinic clinic;
     private Instant createdAt;
-    private Instant startDate;
-    private Instant endDate;
+    private Date startDate;
+    private Date endDate;
     private String comments;
     private String status;
 }

--- a/src/main/java/com/medspace/domain/repository/RentRequestRepository.java
+++ b/src/main/java/com/medspace/domain/repository/RentRequestRepository.java
@@ -9,6 +9,8 @@ public interface RentRequestRepository {
 
     List<RentRequest> findAllRequests();
 
+    List<RentRequest> findByLandlordId(Long landlordId);
+
     RentRequest findRequestById(Long id);
 
     boolean deleteById(Long id);

--- a/src/main/java/com/medspace/domain/repository/RentRequestRepository.java
+++ b/src/main/java/com/medspace/domain/repository/RentRequestRepository.java
@@ -1,6 +1,7 @@
 package com.medspace.domain.repository;
 
 import com.medspace.domain.model.RentRequest;
+import com.medspace.infrastructure.dto.rentRequest.RentRequestQueryFilterDTO;
 import java.util.List;
 
 public interface RentRequestRepository {
@@ -9,7 +10,7 @@ public interface RentRequestRepository {
 
     List<RentRequest> findAllRequests();
 
-    List<RentRequest> findByLandlordId(Long landlordId);
+    List<RentRequest> findByLandlordId(RentRequestQueryFilterDTO filterDTO);
 
     RentRequest findRequestById(Long id);
 

--- a/src/main/java/com/medspace/infrastructure/dto/rentRequest/CreateRentRequestDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/rentRequest/CreateRentRequestDTO.java
@@ -5,8 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.Instant;
+import java.sql.Date;
 
 @Getter
 @Setter
@@ -16,8 +15,8 @@ public class CreateRentRequestDTO {
 
     private Long tenantId;
     private Long clinicId;
-    private Instant startDate;
-    private Instant endDate;
+    private Date startDate;
+    private Date endDate;
     private String comments;
     private String status;
 

--- a/src/main/java/com/medspace/infrastructure/dto/rentRequest/GetRentRequestDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/rentRequest/GetRentRequestDTO.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
+import java.sql.Date;
 import java.time.Instant;
 
 @Getter
@@ -18,8 +18,8 @@ public class GetRentRequestDTO {
     private Long tenantId;
     private Long clinicId;
     private Instant createdAt;
-    private Instant startDate;
-    private Instant endDate;
+    private Date startDate;
+    private Date endDate;
     private String comments;
     private String status;
 

--- a/src/main/java/com/medspace/infrastructure/dto/rentRequest/GetRentRequestPreviewDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/rentRequest/GetRentRequestPreviewDTO.java
@@ -1,0 +1,44 @@
+package com.medspace.infrastructure.dto.rentRequest;
+
+import java.sql.Date;
+import com.medspace.domain.model.Clinic;
+import com.medspace.domain.model.RentRequest;
+import com.medspace.domain.model.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetRentRequestPreviewDTO {
+    private Long id;
+    private Date startDate;
+    private Date endDate;
+    private String comments;
+    private String status;
+
+    private Long tenantId;
+    private Long clinicId;
+
+    private String clinicDisplayName;
+    private String tenantFullName;
+    private String tenantProfilePictureUrl;
+
+    public GetRentRequestPreviewDTO(RentRequest rentRequest, Clinic clinic, User tenant) {
+        this.id = rentRequest.getId();
+        this.startDate = rentRequest.getStartDate();
+        this.endDate = rentRequest.getEndDate();
+        this.comments = rentRequest.getComments();
+        this.status = rentRequest.getStatus().toString();
+
+        this.tenantId = tenant.getId();
+        this.clinicId = clinic.getId();
+
+        this.clinicDisplayName = clinic.getDisplayName();
+        this.tenantFullName = tenant.getFullName();
+        this.tenantProfilePictureUrl = tenant.getProfilePictureUrl();
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/dto/rentRequest/RentRequestQueryFilterDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/rentRequest/RentRequestQueryFilterDTO.java
@@ -1,0 +1,19 @@
+package com.medspace.infrastructure.dto.rentRequest;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RentRequestQueryFilterDTO {
+    private Long landlordId;
+    private String status;
+
+    public RentRequestQueryFilterDTO(Long landlordId) {
+        this.landlordId = landlordId;
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/entity/RentRequestEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/RentRequestEntity.java
@@ -3,7 +3,7 @@ package com.medspace.infrastructure.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
-
+import java.sql.Date;
 import java.time.Instant;
 
 @Getter
@@ -27,10 +27,10 @@ public class RentRequestEntity {
     private Instant createdAt;
 
     @Column(name = "start_date")
-    private Instant startDate;
+    private Date startDate;
 
     @Column(name = "end_date")
-    private Instant endDate;
+    private Date endDate;
 
     @Column(name = "comments")
     private String comments;

--- a/src/main/java/com/medspace/infrastructure/repository/RentRequestRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/RentRequestRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.medspace.domain.model.RentRequest;
 import com.medspace.domain.repository.RentRequestRepository;
 import com.medspace.infrastructure.entity.RentRequestEntity;
 import com.medspace.infrastructure.entity.UserEntity;
+import com.medspace.infrastructure.dto.rentRequest.RentRequestQueryFilterDTO;
 import com.medspace.infrastructure.entity.ClinicEntity;
 import com.medspace.infrastructure.mapper.RentRequestMapper;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
@@ -60,14 +61,18 @@ public class RentRequestRepositoryImpl
     }
 
     @Override
-    public List<RentRequest> findByLandlordId(Long landlordId) {
+    public List<RentRequest> findByLandlordId(RentRequestQueryFilterDTO filterDTO) {
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<RentRequestEntity> cq = cb.createQuery(RentRequestEntity.class);
         Root<RentRequestEntity> root = cq.from(RentRequestEntity.class);
 
         List<Predicate> predicates = new ArrayList<>();
         Join<RentRequestEntity, ClinicEntity> clinicJoin = root.join("clinic", JoinType.INNER);
-        predicates.add(cb.equal(clinicJoin.get("landlord").get("id"), landlordId));
+        predicates.add(cb.equal(clinicJoin.get("landlord").get("id"), filterDTO.getLandlordId()));
+
+        if (filterDTO.getStatus() != null) {
+            predicates.add(cb.equal(root.get("status"), filterDTO.getStatus()));
+        }
 
         cq.select(root).distinct(true).where(cb.and(predicates.toArray(new Predicate[0])));
         List<RentRequestEntity> entities = entityManager.createQuery(cq).getResultList();

--- a/src/main/java/com/medspace/infrastructure/rest/RentRequestController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/RentRequestController.java
@@ -10,6 +10,7 @@ import com.medspace.infrastructure.dto.ResponseDTO;
 import com.medspace.infrastructure.dto.rentRequest.CreateRentRequestDTO;
 import com.medspace.infrastructure.dto.rentRequest.GetRentRequestDTO;
 import com.medspace.infrastructure.dto.rentRequest.GetRentRequestPreviewDTO;
+import com.medspace.infrastructure.dto.rentRequest.RentRequestQueryFilterDTO;
 import com.medspace.infrastructure.rest.annotations.LandlordOnly;
 import com.medspace.infrastructure.rest.context.RequestContext;
 import jakarta.inject.Inject;
@@ -49,10 +50,14 @@ public class RentRequestController {
     @GET
     @Path("/landlord")
     @LandlordOnly
-    public Response getByLandlord() {
+    public Response getByLandlord(@QueryParam("status") String targetStatus) {
         User loggedInUser = requestContext.getUser();
-        List<GetRentRequestPreviewDTO> list =
-                getRentRequestsByLandlordId.execute(loggedInUser.getId());
+        RentRequestQueryFilterDTO filterDTO = new RentRequestQueryFilterDTO(loggedInUser.getId());
+        if (targetStatus != null) {
+            filterDTO.setStatus(targetStatus);
+        }
+
+        List<GetRentRequestPreviewDTO> list = getRentRequestsByLandlordId.execute(filterDTO);
 
         return Response.ok(ResponseDTO.success("Fetched rent-requests", list)).build();
     }

--- a/src/main/java/com/medspace/infrastructure/rest/RentRequestController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/RentRequestController.java
@@ -3,10 +3,14 @@ package com.medspace.infrastructure.rest;
 import com.medspace.application.usecase.rentRequest.CreateRentRequestUseCase;
 import com.medspace.application.usecase.rentRequest.ListRentRequestUseCase;
 import com.medspace.application.usecase.rentRequest.DeleteRentRequestUseCase;
+import com.medspace.application.usecase.rentRequest.GetRentRequestsByLandlordIdUseCase;
 import com.medspace.domain.model.RentRequest;
+import com.medspace.domain.model.User;
 import com.medspace.infrastructure.dto.ResponseDTO;
 import com.medspace.infrastructure.dto.rentRequest.CreateRentRequestDTO;
 import com.medspace.infrastructure.dto.rentRequest.GetRentRequestDTO;
+import com.medspace.infrastructure.rest.annotations.LandlordOnly;
+import com.medspace.infrastructure.rest.context.RequestContext;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -22,16 +26,31 @@ public class RentRequestController {
 
     @Inject
     CreateRentRequestUseCase createRentRequest;
-
     @Inject
     ListRentRequestUseCase listRentRequests;
-
     @Inject
     DeleteRentRequestUseCase deleteRentRequest;
+    @Inject
+    GetRentRequestsByLandlordIdUseCase getRentRequestsByLandlordId;
+
+    @Inject
+    RequestContext requestContext;
 
     @GET
     public Response getAll() {
         List<RentRequest> list = listRentRequests.execute();
+        List<GetRentRequestDTO> dtos =
+                list.stream().map(GetRentRequestDTO::new).collect(Collectors.toList());
+
+        return Response.ok(ResponseDTO.success("Fetched rent-requests", dtos)).build();
+    }
+
+    @GET
+    @Path("/landlord")
+    @LandlordOnly
+    public Response getByLandlord() {
+        User loggedInUser = requestContext.getUser();
+        List<RentRequest> list = getRentRequestsByLandlordId.execute(loggedInUser.getId());
         List<GetRentRequestDTO> dtos =
                 list.stream().map(GetRentRequestDTO::new).collect(Collectors.toList());
 

--- a/src/main/java/com/medspace/infrastructure/rest/RentRequestController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/RentRequestController.java
@@ -9,6 +9,7 @@ import com.medspace.domain.model.User;
 import com.medspace.infrastructure.dto.ResponseDTO;
 import com.medspace.infrastructure.dto.rentRequest.CreateRentRequestDTO;
 import com.medspace.infrastructure.dto.rentRequest.GetRentRequestDTO;
+import com.medspace.infrastructure.dto.rentRequest.GetRentRequestPreviewDTO;
 import com.medspace.infrastructure.rest.annotations.LandlordOnly;
 import com.medspace.infrastructure.rest.context.RequestContext;
 import jakarta.inject.Inject;
@@ -50,11 +51,10 @@ public class RentRequestController {
     @LandlordOnly
     public Response getByLandlord() {
         User loggedInUser = requestContext.getUser();
-        List<RentRequest> list = getRentRequestsByLandlordId.execute(loggedInUser.getId());
-        List<GetRentRequestDTO> dtos =
-                list.stream().map(GetRentRequestDTO::new).collect(Collectors.toList());
+        List<GetRentRequestPreviewDTO> list =
+                getRentRequestsByLandlordId.execute(loggedInUser.getId());
 
-        return Response.ok(ResponseDTO.success("Fetched rent-requests", dtos)).build();
+        return Response.ok(ResponseDTO.success("Fetched rent-requests", list)).build();
     }
 
     @POST


### PR DESCRIPTION
## Summary
This PR introduces a new useCase that queries all the RentRequests associated to the currently logged in landlord. 

## Context
This PR forms part of this [Jira Task](https://paez-tec.atlassian.net/browse/MED-24?atlOrigin=eyJpIjoiOTEwZjQyMWVjNjhiNGFmMWE2MzUxNDVkM2E2NjI2MTQiLCJwIjoiaiJ9)

## Test Plan
GET /rent-requests/landlord
<img width="907" alt="Captura de pantalla 2025-05-04 a la(s) 12 46 33 p m" src="https://github.com/user-attachments/assets/80faab08-0b51-4206-9a5d-6d2cd5d1fcf4" />
