### PR TITLE
feature(clinic): implement MyClinicDTO and update clinic retrieval to…

### DIFF
--- a/src/main/java/com/medspace/application/usecase/clinic/GetClinicsByLandlordIdUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinic/GetClinicsByLandlordIdUseCase.java
@@ -1,8 +1,13 @@
 package com.medspace.application.usecase.clinic;
 
+import java.util.ArrayList;
 import java.util.List;
+import com.medspace.application.service.ClinicPhotoService;
 import com.medspace.application.service.ClinicService;
 import com.medspace.domain.model.Clinic;
+import com.medspace.domain.model.ClinicPhoto;
+import com.medspace.infrastructure.dto.clinic.GetClinicPhotoDTO;
+import com.medspace.infrastructure.dto.clinic.MyClinicDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -11,7 +16,37 @@ public class GetClinicsByLandlordIdUseCase {
     @Inject
     ClinicService clinicService;
 
-    public List<Clinic> execute(Long landlordId) {
-        return clinicService.getClinicsByLandlordId(landlordId);
+    @Inject
+    ClinicPhotoService clinicPhotoService;
+
+    public List<MyClinicDTO> execute(Long landlordId) {
+        List<Clinic> clinics = clinicService.getClinicsByLandlordId(landlordId);
+        List<MyClinicDTO> myClinics = new ArrayList<>();
+
+        for (Clinic clinic : clinics) {
+            List<ClinicPhoto> clinicPhotos =
+                    clinicPhotoService.listPhotosByClinicId(clinic.getId());
+
+            // Find primary photo or use the first one if available
+            ClinicPhoto mainPhoto = null;
+            if (!clinicPhotos.isEmpty()) {
+                // First try to find the primary photo
+                for (ClinicPhoto photo : clinicPhotos) {
+                    if (photo.getIsPrimary()) {
+                        mainPhoto = photo;
+                        break;
+                    }
+                }
+
+                // If no primary photo found, use the first one
+                if (mainPhoto == null) {
+                    mainPhoto = clinicPhotos.get(0);
+                }
+            }
+
+            myClinics.add(new MyClinicDTO(clinic, new GetClinicPhotoDTO(mainPhoto)));
+        }
+
+        return myClinics;
     }
 }

--- a/src/main/java/com/medspace/infrastructure/dto/clinic/MyClinicDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/clinic/MyClinicDTO.java
@@ -1,0 +1,28 @@
+package com.medspace.infrastructure.dto.clinic;
+
+
+import com.medspace.domain.model.Clinic;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyClinicDTO {
+    private Long id;
+
+    private String displayName;
+    private String addressState;
+    private String mainPhotoPath;
+
+
+    public MyClinicDTO(Clinic clinic, GetClinicPhotoDTO mainPhoto) {
+        this.id = clinic.getId();
+        this.displayName = clinic.getDisplayName();
+        this.addressState = clinic.getAddressState();
+        this.mainPhotoPath = mainPhoto.getPath();
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/entity/ClinicEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/ClinicEntity.java
@@ -82,4 +82,8 @@ public class ClinicEntity {
 
     @OneToMany(mappedBy = "clinic", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Set<ReviewEntity> reviews;
+
+    @OneToMany(mappedBy = "clinic", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Set<RentRequestEntity> rentRequests;
+
 }

--- a/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/ClinicController.java
@@ -15,6 +15,7 @@ import com.medspace.infrastructure.dto.clinic.GetClinicAvailabilityDTO;
 import com.medspace.infrastructure.dto.clinic.GetClinicDTO;
 import com.medspace.infrastructure.dto.clinic.GetClinicEquipmentDTO;
 import com.medspace.infrastructure.dto.clinic.GetClinicPhotoDTO;
+import com.medspace.infrastructure.dto.clinic.MyClinicDTO;
 import com.medspace.infrastructure.dto.clinic.SetPhotoAsPrimaryDTO;
 import com.medspace.infrastructure.rest.annotations.LandlordOnly;
 import com.medspace.infrastructure.rest.annotations.UserOnly;
@@ -120,12 +121,14 @@ public class ClinicController {
     }
 
     @GET
-    @Path("/landlord")
+    @Path("/my-clinics")
     @LandlordOnly
     public Response getAllClinicsByLandlord() {
         try {
             User loggedInUser = requestContext.getUser();
-            List<Clinic> clinics = getClinicsByLandlordIdUseCase.execute(loggedInUser.getId());
+
+            List<MyClinicDTO> clinics = getClinicsByLandlordIdUseCase.execute(loggedInUser.getId());
+
             return Response.ok(ResponseDTO.success("Clinics Fetched", clinics)).build();
         } catch (Exception e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## Overview
This PR implements a new `MyClinicDTO` class and updates the clinic retrieval process to include primary photos for the landlord's clinic view.

## Changes
- Created a new `MyClinicDTO` class for simplified clinic representation
- Enhanced `GetClinicsByLandlordIdUseCase` to return DTOs with photo data
- Updated clinic entity with rent request relationship
- Renamed endpoint from `/landlord` to `/my-clinics`

## Implementation Details

### 1. Created `MyClinicDTO`
Added a simplified DTO with essential clinic information:
- ID
- Display name
- Address state
- Main photo path

### 2. Enhanced `GetClinicsByLandlordIdUseCase`
- Now returns `List<MyClinicDTO>` instead of `List<Clinic>`
- Includes logic to find primary photos:
  - Prioritizes photos marked as primary
  - Falls back to first available photo
  - Handles cases with no photos

### 3. Updated `ClinicEntity`
- Added relationship mapping for rent requests, so it can cascade delete

### 4. Modified `ClinicController`
- Renamed endpoint to `/my-clinics`
- Updated response format to use new DTOs
