### PR TITLE
Feature: Implement accept and reject rent request logic

### DIFF
--- a/src/main/java/com/medspace/application/service/RentService.java
+++ b/src/main/java/com/medspace/application/service/RentService.java
@@ -55,6 +55,34 @@ public class RentService {
         return rentRequestDayRepository.getRentRequestDaysByRentRequestId(rentRequestId);
     }
 
+    public void updateRentRequestStatus(Long rentRequestId, RentRequest.Status status) {
+        rentRequestRepository.updateRentRequestStatus(rentRequestId, status);
+    }
+
+    public Boolean validateRentRequestOwnership(Long rentRequestId, Long userId) {
+        if (rentRequestId == null || userId == null) {
+            return false;
+        }
+        RentRequest rentRequest = rentRequestRepository.findRequestById(rentRequestId);
+        if (rentRequest == null || rentRequest.getTenant() == null) {
+            return false;
+        }
+        return rentRequest.getClinic().getLandlord().getId().equals(userId);
+    }
+
+    public Boolean isRentRequestPending(Long rentRequestId) {
+        RentRequest rentRequest = rentRequestRepository.findRequestById(rentRequestId);
+        return rentRequest.getStatus() == RentRequest.Status.PENDING;
+    }
+
+    public Boolean processRentRequestPayment(Long rentRequestId) {
+        Boolean hasPendingStatus = isRentRequestPending(rentRequestId);
+        if (!hasPendingStatus) {
+            throw new IllegalArgumentException("Rent request is already processed");
+        }
+        return true;
+    }
+
     // Review methods
 
     public Review createReview(Review review) {

--- a/src/main/java/com/medspace/application/usecase/rent/AcceptRentRequestUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/rent/AcceptRentRequestUseCase.java
@@ -1,0 +1,27 @@
+package com.medspace.application.usecase.rent;
+
+import com.medspace.application.service.RentService;
+import com.medspace.domain.model.RentRequest;
+import io.quarkus.security.ForbiddenException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class AcceptRentRequestUseCase {
+    @Inject
+    RentService rentService;
+
+    public Boolean execute(Long rentRequestId, Long loggedUserId) {
+        Boolean isOwner = rentService.validateRentRequestOwnership(rentRequestId, loggedUserId);
+        if (!isOwner) {
+            throw new ForbiddenException("Accept unauthorized");
+        }
+
+        Boolean isPaymentSuccessful = rentService.processRentRequestPayment(rentRequestId);
+        RentRequest.Status status =
+                isPaymentSuccessful ? RentRequest.Status.ACCEPTED : RentRequest.Status.REJECTED;
+
+        rentService.updateRentRequestStatus(rentRequestId, status);
+        return isPaymentSuccessful;
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/rent/RejectRentRequestUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/rent/RejectRentRequestUseCase.java
@@ -1,0 +1,26 @@
+package com.medspace.application.usecase.rent;
+
+import com.medspace.domain.model.RentRequest;
+import com.medspace.application.service.RentService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class RejectRentRequestUseCase {
+    @Inject
+    RentService rentService;
+
+    public void execute(Long rentRequestId, Long loggedUserId) {
+        Boolean isOnwer = rentService.validateRentRequestOwnership(rentRequestId, loggedUserId);
+        if (!isOnwer) {
+            throw new IllegalArgumentException("Reject unauthorized");
+        }
+        Boolean isPending = rentService.isRentRequestPending(rentRequestId);
+        if (!isPending) {
+            throw new IllegalArgumentException("Rent request is already processed");
+        }
+
+        rentService.updateRentRequestStatus(rentRequestId, RentRequest.Status.REJECTED);
+    }
+
+}

--- a/src/main/java/com/medspace/domain/repository/RentRequestRepository.java
+++ b/src/main/java/com/medspace/domain/repository/RentRequestRepository.java
@@ -14,5 +14,7 @@ public interface RentRequestRepository {
 
     RentRequest findRequestById(Long id);
 
+    void updateRentRequestStatus(Long id, RentRequest.Status status);
+
     boolean deleteById(Long id);
 }

--- a/src/main/java/com/medspace/infrastructure/repository/RentRequestRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/RentRequestRepositoryImpl.java
@@ -97,4 +97,15 @@ public class RentRequestRepositoryImpl
         }
         return true;
     }
+
+    @Override
+    @Transactional
+    public void updateRentRequestStatus(Long id, RentRequest.Status status) {
+        RentRequestEntity entity = findById(id);
+        if (entity == null) {
+            throw new NotFoundException("RentRequest with id " + id + " not found");
+        }
+        entity.setStatus(status);
+        persist(entity);
+    }
 }


### PR DESCRIPTION
## Summary
This PR introduces new endpoints to accept or reject a given pending rent request:
`/rent-requests/{id}/accept`
`/rent-requests/{id}/reject`

## Test Plan
Accept
<img width="916" alt="Captura de pantalla 2025-05-10 a la(s) 8 21 52 p m" src="https://github.com/user-attachments/assets/cf596181-2b4e-4b63-903f-476a1c9d007f" />


Reject
<img width="877" alt="Captura de pantalla 2025-05-10 a la(s) 8 21 09 p m" src="https://github.com/user-attachments/assets/86d78f23-f181-481f-b6cb-9d35a5ea6143" />


Error
<img width="906" alt="Captura de pantalla 2025-05-10 a la(s) 8 20 54 p m" src="https://github.com/user-attachments/assets/dfa276ce-0b31-4b1a-9464-2456619701f1" />
