### PR TITLE
feature(user): implement self user deletion route and fix public user…

### DIFF
--- a/src/main/java/com/medspace/infrastructure/dto/user/GetUserPublicProfileDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/user/GetUserPublicProfileDTO.java
@@ -17,7 +17,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class GetUserPublicProfileDTO {
     private Long id;
-    private String fullname;
+    private String fullName;
     private Double averageRating; // average rating of User, or null if there are no ratings
     private TenantSpecialty tenantSpecialty;
     private User.UserType userType;
@@ -30,7 +30,7 @@ public class GetUserPublicProfileDTO {
     public GetUserPublicProfileDTO(User user, Double userAverageRating, List<GetReviewDTO> reviews,
             List<GetClinicPreviewDTO> ownedClinics) {
         this.id = user.getId();
-        this.fullname = user.getFullName();
+        this.fullName = user.getFullName();
         this.averageRating = userAverageRating;
         this.tenantSpecialty = user.getTenantSpecialty();
         this.userType = user.getUserType();

--- a/src/main/java/com/medspace/infrastructure/rest/UserController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/UserController.java
@@ -106,28 +106,6 @@ public class UserController {
         }
     }
 
-
-    @DELETE
-    @Path("/{id}")
-    public Response deleteUser(@PathParam("id") Long id) {
-        try {
-            deleteUserByIdUseCase.execute(id);
-
-            return Response.ok(ResponseDTO.success("User Deleted")).build();
-
-        } catch (Exception e) {
-
-            if (e.getMessage().contains("not found")) {
-                return Response.status(Response.Status.NOT_FOUND)
-                        .entity(ResponseDTO.error(e.getMessage())).build();
-            }
-
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(ResponseDTO.error(e.getMessage())).build();
-        }
-    }
-
-
     @GET
     @Path("/{id}")
     public Response getUser(@PathParam("id") Long id) {
@@ -217,6 +195,30 @@ public class UserController {
                     .entity(ResponseDTO.error(e.getMessage())).build();
         }
 
+    }
+
+
+    @DELETE
+    @UserOnly
+    @Path("/me")
+    public Response deleteUser() {
+        try {
+            User user = requestContext.getUser();
+
+            deleteUserByIdUseCase.execute(user.getId());
+
+            return Response.ok(ResponseDTO.success("User Deleted")).build();
+
+        } catch (Exception e) {
+
+            if (e.getMessage().contains("not found")) {
+                return Response.status(Response.Status.NOT_FOUND)
+                        .entity(ResponseDTO.error(e.getMessage())).build();
+            }
+
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage())).build();
+        }
     }
 
 }


### PR DESCRIPTION
# User Account Management Improvements

## Changes
- Implemented user self-deletion endpoint at `/users/me` with `@UserOnly` annotation for security
- Fixed inconsistent naming in `GetUserPublicProfileDTO` (`fullname` → `fullName`)
- Removed redundant admin-only user deletion endpoint (`/users/{id}`)

## Why these changes?
- Users should have the ability to delete their own accounts (right to erasure)
- Moving user deletion to a self-service endpoint improves security by preventing admins from accidentally deleting user accounts
- Fixed inconsistent naming convention for better code quality and API consistency