### PR TITLE
Fix: typo in create user dto

### DIFF
--- a/src/main/java/com/medspace/infrastructure/dto/user/CreateUserDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/user/CreateUserDTO.java
@@ -36,7 +36,7 @@ public class CreateUserDTO {
     private String bio;
 
     @NotNull
-    @Pattern(regexp = " LANDLORD|TENANT|ANALYST",
+    @Pattern(regexp = "LANDLORD|TENANT|ANALYST",
             message = "User type must be one of: LANDLORD, TENANT, ANALYST")
     private String userType;
 


### PR DESCRIPTION
## Summary
This PR fixes a bug that caused the dto to expect invalid values for the user type. It fixes a typo that solves the issue