### PR TITLE
feature(meatrics): Endpoint, dto, use case and repositories changes for accesing specialists dashboard data

### DIFF
--- a/src/main/java/com/medspace/application/service/RentService.java
+++ b/src/main/java/com/medspace/application/service/RentService.java
@@ -14,6 +14,7 @@ import com.medspace.domain.repository.RentRequestRepository;
 import com.medspace.domain.repository.ReviewRepository;
 import com.medspace.domain.repository.UserRepository;
 import com.medspace.infrastructure.dto.rentRequest.RentRequestQueryFilterDTO;
+import com.medspace.infrastructure.dto.rentRequest.GetRentRequestSpecialistsDashboardDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
@@ -186,5 +187,9 @@ public class RentService {
     public boolean validatePaymentOwnership(Long paymentId, Long userId) {
         // For now, always return true to allow all actions
         return true;
+    }
+
+    public List<GetRentRequestSpecialistsDashboardDTO> getSpecialistsDashboardData() {
+        return rentRequestRepository.getSpecialistsDashboardData();
     }
 }

--- a/src/main/java/com/medspace/application/usecase/rent/GetSpecialistsDashboardDataUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/rent/GetSpecialistsDashboardDataUseCase.java
@@ -1,0 +1,17 @@
+package com.medspace.application.usecase.rent;
+
+import java.util.List;
+import com.medspace.application.service.RentService;
+import com.medspace.infrastructure.dto.rentRequest.GetRentRequestSpecialistsDashboardDTO;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class GetSpecialistsDashboardDataUseCase {
+    @Inject
+    RentService rentService;
+
+    public List<GetRentRequestSpecialistsDashboardDTO> execute() {
+        return rentService.getSpecialistsDashboardData();
+    }
+} 

--- a/src/main/java/com/medspace/domain/repository/RentRequestRepository.java
+++ b/src/main/java/com/medspace/domain/repository/RentRequestRepository.java
@@ -2,7 +2,10 @@ package com.medspace.domain.repository;
 
 import com.medspace.domain.model.RentRequest;
 import com.medspace.infrastructure.dto.rentRequest.RentRequestQueryFilterDTO;
+
 import java.util.List;
+
+import com.medspace.infrastructure.dto.rentRequest.GetRentRequestSpecialistsDashboardDTO;
 
 public interface RentRequestRepository {
 
@@ -17,4 +20,6 @@ public interface RentRequestRepository {
     void updateRentRequestStatus(Long id, RentRequest.Status status);
 
     boolean deleteById(Long id);
+
+    List<GetRentRequestSpecialistsDashboardDTO> getSpecialistsDashboardData();
 }

--- a/src/main/java/com/medspace/infrastructure/dto/rentRequest/GetRentRequestSpecialistsDashboardDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/rentRequest/GetRentRequestSpecialistsDashboardDTO.java
@@ -1,0 +1,25 @@
+package com.medspace.infrastructure.dto.rentRequest;
+
+import com.medspace.domain.model.RentRequest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.time.Instant;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetRentRequestSpecialistsDashboardDTO {
+    private Long rentRequestId;
+    private String tenantName;
+    private String clinicName;
+    private RentRequest.Status status;
+    private Instant createdAt;
+    private String tenantSpecialty;
+    private String clinicAddress;
+    private String clinicBorough;
+    private Double clinicLatitude;
+    private Double clinicLongitude;
+}

--- a/src/main/java/com/medspace/infrastructure/repository/RentRequestRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/RentRequestRepositoryImpl.java
@@ -121,7 +121,10 @@ public class RentRequestRepositoryImpl
         Join<RentRequestEntity, ClinicEntity> clinicJoin = root.join("clinic", JoinType.INNER);
         Join<UserEntity, TenantSpecialtyEntity> specialtyJoin = tenantJoin.join("tenantSpecialty", JoinType.LEFT);
 
-        cq.select(root).distinct(true);
+        // Add predicate to filter only accepted requests
+        Predicate acceptedStatus = cb.equal(root.get("status"), RentRequest.Status.ACCEPTED);
+        cq.select(root).distinct(true).where(acceptedStatus);
+        
         List<RentRequestEntity> entities = entityManager.createQuery(cq).getResultList();
 
         return entities.stream()

--- a/src/main/java/com/medspace/infrastructure/rest/RentRequestController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/RentRequestController.java
@@ -8,6 +8,7 @@ import com.medspace.application.usecase.rent.GetRentRequestsByLandlordIdUseCase;
 import com.medspace.application.usecase.rent.ListRentRequestDaysUseCase;
 import com.medspace.application.usecase.rent.ListRentRequestUseCase;
 import com.medspace.application.usecase.rent.RejectRentRequestUseCase;
+import com.medspace.application.usecase.rent.GetSpecialistsDashboardDataUseCase;
 import com.medspace.domain.model.RentRequest;
 import com.medspace.domain.model.RentRequestDay;
 import com.medspace.domain.model.User;
@@ -18,6 +19,7 @@ import com.medspace.infrastructure.dto.rentRequest.GetRentRequestDTO;
 import com.medspace.infrastructure.dto.rentRequest.GetRentRequestDayDTO;
 import com.medspace.infrastructure.dto.rentRequest.GetRentRequestPreviewDTO;
 import com.medspace.infrastructure.dto.rentRequest.RentRequestQueryFilterDTO;
+import com.medspace.infrastructure.dto.rentRequest.GetRentRequestSpecialistsDashboardDTO;
 import com.medspace.infrastructure.rest.annotations.LandlordOnly;
 import com.medspace.infrastructure.rest.annotations.TenantOnly;
 import com.medspace.infrastructure.rest.context.RequestContext;
@@ -50,6 +52,8 @@ public class RentRequestController {
     AcceptRentRequestUseCase acceptRentRequestUseCase;
     @Inject
     RejectRentRequestUseCase rejectRentRequestUseCase;
+    @Inject
+    GetSpecialistsDashboardDataUseCase getSpecialistsDashboardDataUseCase;
 
     @Inject
     RequestContext requestContext;
@@ -171,6 +175,13 @@ public class RentRequestController {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                     .entity(ResponseDTO.error(e.getMessage())).build();
         }
+    }
+
+    @GET
+    @Path("/specialists-dashboard")
+    public Response getSpecialistsDashboardData() {
+        List<GetRentRequestSpecialistsDashboardDTO> data = getSpecialistsDashboardDataUseCase.execute();
+        return Response.ok(ResponseDTO.success("Fetched specialists dashboard data", data)).build();
     }
 
 }


### PR DESCRIPTION
# Specialists Dashboard Implementation

## Overview
This PR implements the specialists dashboard functionality, which provides a comprehensive view of accepted rent requests across all clinics, including tenant specialties and clinic location information.

## Changes Made

### New DTO
- Created `GetRentRequestSpecialistsDashboardDTO` to structure the dashboard data with:
  - Rent request details (ID, status, creation date)
  - Tenant information (name, specialty)
  - Clinic information (name, address, borough, coordinates)

### Repository Layer
- Implemented `getSpecialistsDashboardData()` in `RentRequestRepositoryImpl`
  - Added filtering to only return ACCEPTED rent requests
  - Included joins to fetch tenant and clinic information
  - Added tenant specialty information through a left join
  - Mapped all required fields to the DTO

### Service Layer
- Added `getSpecialistsDashboardData()` method to `RentService`
  - Delegates to repository implementation
  - Maintains clean separation of concerns

### Use Case
- Created `GetSpecialistsDashboardDataUseCase`
  - Handles the business logic for retrieving dashboard data
  - Injects and uses `RentService`

### Controller
- Added new endpoint `/rent-requests/specialists-dashboard`
  - Returns list of `GetRentRequestSpecialistsDashboardDTO`
  - Properly wrapped in `ResponseDTO` for consistent API responses

## Testing
The implementation has been tested with:
- Multiple tenants requesting the same clinic
- Different specialties across various clinics
- Proper handling of tenant specialty information
- Correct mapping of clinic location data

<img width="1610" alt="image" src="https://github.com/user-attachments/assets/de1ed6e1-5d74-414c-8204-010538b89236" />
<img width="1647" alt="image" src="https://github.com/user-attachments/assets/f5379608-dcfd-4541-a899-844780fc37bc" />
<img width="1649" alt="image" src="https://github.com/user-attachments/assets/295357b5-f0b6-42e3-8deb-653cff997acb" />
<img width="1643" alt="image" src="https://github.com/user-attachments/assets/7b9fa0ba-595e-4870-a297-cd755957935e" />
<img width="1647" alt="image" src="https://github.com/user-attachments/assets/63498401-6537-4679-8a14-65c8f81c242d" />
