### PR TITLE
Feature: add cancel rent request status

### DIFF
--- a/src/main/java/com/medspace/application/service/RentService.java
+++ b/src/main/java/com/medspace/application/service/RentService.java
@@ -84,6 +84,17 @@ public class RentService {
         return rentRequest.getClinic().getLandlord().getId().equals(userId);
     }
 
+    public Boolean validateRentRequestSentByTenant(Long rentRequestId, Long tenantId) {
+        if (rentRequestId == null || tenantId == null) {
+            return false;
+        }
+        RentRequest rentRequest = rentRequestRepository.findRequestById(rentRequestId);
+        if (rentRequest == null || rentRequest.getTenant() == null) {
+            return false;
+        }
+        return rentRequest.getTenant().getId().equals(tenantId);
+    }
+
     public Boolean isRentRequestPending(Long rentRequestId) {
         RentRequest rentRequest = rentRequestRepository.findRequestById(rentRequestId);
         return rentRequest.getStatus() == RentRequest.Status.PENDING;

--- a/src/main/java/com/medspace/application/usecase/rent/CancelRentRequestUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/rent/CancelRentRequestUseCase.java
@@ -1,0 +1,24 @@
+package com.medspace.application.usecase.rent;
+
+import com.medspace.application.service.RentService;
+import com.medspace.domain.model.RentRequest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class CancelRentRequestUseCase {
+    @Inject
+    RentService rentService;
+
+    public void execute(Long rentRequestId, Long loggedUserId) {
+        Boolean isSender = rentService.validateRentRequestSentByTenant(rentRequestId, loggedUserId);
+        if (!isSender) {
+            throw new IllegalArgumentException("Cancel unauthorized");
+        }
+        Boolean isPending = rentService.isRentRequestPending(rentRequestId);
+        if (!isPending) {
+            throw new IllegalArgumentException("Rent request is already processed");
+        }
+        rentService.updateRentRequestStatus(rentRequestId, RentRequest.Status.CANCELED);
+    }
+}

--- a/src/main/java/com/medspace/domain/model/RentRequest.java
+++ b/src/main/java/com/medspace/domain/model/RentRequest.java
@@ -13,9 +13,8 @@ import java.time.Instant;
 @AllArgsConstructor
 public class RentRequest {
     public enum Status {
-        PENDING, ACCEPTED, REJECTED
+        PENDING, ACCEPTED, REJECTED, CANCELED
     }
-
 
     private Long id;
     private User tenant;

--- a/src/main/java/com/medspace/infrastructure/dto/rentRequest/GetRentRequestPreviewDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/rentRequest/GetRentRequestPreviewDTO.java
@@ -21,6 +21,7 @@ public class GetRentRequestPreviewDTO {
     private String status;
 
     private Long tenantId;
+    private Long landlordId;
     private Long clinicId;
 
     private String clinicDisplayName;
@@ -31,6 +32,9 @@ public class GetRentRequestPreviewDTO {
     private String tenantFullName;
     private String tenantProfilePictureUrl;
     private String tenantSpecialty;
+
+    private String landlordFullName;
+    private String landlordProfilePictureUrl;
 
     private List<Date> requestedDays;
 
@@ -53,6 +57,10 @@ public class GetRentRequestPreviewDTO {
         this.tenantFullName = tenant.getFullName();
         this.tenantProfilePictureUrl = tenant.getPfpPath();
         this.tenantSpecialty = tenant.getTenantSpecialty().getName();
+
+        this.landlordId = clinic.getLandlord().getId();
+        this.landlordFullName = clinic.getLandlord().getFullName();
+        this.landlordProfilePictureUrl = clinic.getLandlord().getPfpPath();
 
         this.requestedDays = requestedDays;
     }

--- a/src/main/java/com/medspace/infrastructure/entity/ClinicEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/ClinicEntity.java
@@ -1,7 +1,6 @@
 package com.medspace.infrastructure.entity;
 
 import com.medspace.domain.model.Clinic;
-import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/medspace/infrastructure/rest/RentRequestController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/RentRequestController.java
@@ -1,6 +1,7 @@
 package com.medspace.infrastructure.rest;
 
 import com.medspace.application.usecase.rent.AcceptRentRequestUseCase;
+import com.medspace.application.usecase.rent.CancelRentRequestUseCase;
 import com.medspace.application.usecase.rent.CreateRentRequestDaysUseCase;
 import com.medspace.application.usecase.rent.CreateRentRequestUseCase;
 import com.medspace.application.usecase.rent.DeleteRentRequestUseCase;
@@ -53,6 +54,8 @@ public class RentRequestController {
     AcceptRentRequestUseCase acceptRentRequestUseCase;
     @Inject
     RejectRentRequestUseCase rejectRentRequestUseCase;
+    @Inject
+    CancelRentRequestUseCase cancelRentRequestUseCase;
     @Inject
     GetSpecialistsDashboardDataUseCase getSpecialistsDashboardDataUseCase;
 
@@ -139,6 +142,20 @@ public class RentRequestController {
         }
     }
 
+    @PUT
+    @Path("{id}/cancel")
+    @TenantOnly
+    public Response cancelRentRequest(@PathParam("id") Long id) {
+        try {
+            User loggedInUser = requestContext.getUser();
+            cancelRentRequestUseCase.execute(id, loggedInUser.getId());
+            return Response.ok(ResponseDTO.success("Cancelled rent-request")).build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(ResponseDTO.error(e.getMessage())).build();
+        }
+    }
+
     @DELETE
     @Path("{id}")
     public Response deleteRentRequest(@PathParam("id") Long id) {
@@ -181,7 +198,8 @@ public class RentRequestController {
     @GET
     @Path("/specialists-dashboard")
     public Response getSpecialistsDashboardData() {
-        List<GetRentRequestSpecialistsDashboardDTO> data = getSpecialistsDashboardDataUseCase.execute();
+        List<GetRentRequestSpecialistsDashboardDTO> data =
+                getSpecialistsDashboardDataUseCase.execute();
         return Response.ok(ResponseDTO.success("Fetched specialists dashboard data", data)).build();
     }
 


### PR DESCRIPTION
## Summary
This PR introduces a new RentRequest.status = CANCELED, so that the tenant user can cancel a pending rent request. It also updates the request preview dto to align with frontend expectations

## Test Plan
<img width="1344" alt="Captura de pantalla 2025-05-15 a la(s) 11 49 06 a m" src="https://github.com/user-attachments/assets/dc3e03c7-9a7b-4b98-8145-e66481a701c2" />

