### PR TITLE
Refactor: Change queries to use ORM

### DIFF
--- a/src/main/java/com/medspace/infrastructure/dto/rentRequest/RentRequestQueryFilterDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/rentRequest/RentRequestQueryFilterDTO.java
@@ -1,5 +1,6 @@
 package com.medspace.infrastructure.dto.rentRequest;
 
+import com.medspace.domain.model.RentRequest;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class RentRequestQueryFilterDTO {
     private Long userId;
-    private String status;
+    private RentRequest.Status status;
 
     public RentRequestQueryFilterDTO(Long userId) {
         this.userId = userId;

--- a/src/main/java/com/medspace/infrastructure/entity/UserEntity.java
+++ b/src/main/java/com/medspace/infrastructure/entity/UserEntity.java
@@ -66,4 +66,7 @@ public class UserEntity extends PanacheEntityBase {
 
     @OneToMany(mappedBy = "landlord", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<ClinicEntity> clinics;
+
+    @OneToMany(mappedBy = "tenant", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<RentRequestEntity> rentRequests;
 }

--- a/src/main/java/com/medspace/infrastructure/repository/RentRequestRepositoryImpl.java
+++ b/src/main/java/com/medspace/infrastructure/repository/RentRequestRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.medspace.infrastructure.mapper.RentRequestMapper;
 import com.medspace.infrastructure.dto.rentRequest.GetRentRequestSpecialistsDashboardDTO;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -28,6 +29,9 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class RentRequestRepositoryImpl
         implements RentRequestRepository, PanacheRepository<RentRequestEntity> {
+
+    @Inject
+    ClinicRepositoryImpl clinicRepository;
 
     @PersistenceContext
     EntityManager entityManager;
@@ -64,20 +68,22 @@ public class RentRequestRepositoryImpl
 
     @Override
     public List<RentRequest> findByLandlordId(RentRequestQueryFilterDTO filterDTO) {
-        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-        CriteriaQuery<RentRequestEntity> cq = cb.createQuery(RentRequestEntity.class);
-        Root<RentRequestEntity> root = cq.from(RentRequestEntity.class);
+        List<ClinicEntity> clinics =
+                clinicRepository.find("landlord.id", filterDTO.getUserId()).list();
 
-        List<Predicate> predicates = new ArrayList<>();
-        Join<RentRequestEntity, ClinicEntity> clinicJoin = root.join("clinic", JoinType.INNER);
-        predicates.add(cb.equal(clinicJoin.get("landlord").get("id"), filterDTO.getUserId()));
-
-        if (filterDTO.getStatus() != null) {
-            predicates.add(cb.equal(root.get("status"), filterDTO.getStatus()));
+        if (clinics.isEmpty()) {
+            return new ArrayList<>();
         }
 
-        cq.select(root).distinct(true).where(cb.and(predicates.toArray(new Predicate[0])));
-        List<RentRequestEntity> entities = entityManager.createQuery(cq).getResultList();
+        List<RentRequestEntity> entities = clinics.stream().flatMap(clinic -> {
+            List<RentRequestEntity> rentRequests =
+                    (filterDTO.getStatus() != null)
+                            ? find("clinic.id = ?1 and status = ?2", clinic.getId(),
+                                    filterDTO.getStatus()).list()
+                            : find("clinic.id", clinic.getId()).list();
+            return rentRequests.stream();
+        }).collect(Collectors.toList());
+
         return entities.stream().map(RentRequestMapper::toDomain).collect(Collectors.toList());
     }
 
@@ -87,7 +93,7 @@ public class RentRequestRepositoryImpl
 
         if (filterDTO.getStatus() != null) {
             entities = entities.stream()
-                    .filter(entity -> entity.getStatus().toString().equals(filterDTO.getStatus()))
+                    .filter(entity -> entity.getStatus().equals(filterDTO.getStatus()))
                     .collect(Collectors.toList());
         }
 
@@ -132,37 +138,37 @@ public class RentRequestRepositoryImpl
 
         Join<RentRequestEntity, UserEntity> tenantJoin = root.join("tenant", JoinType.INNER);
         Join<RentRequestEntity, ClinicEntity> clinicJoin = root.join("clinic", JoinType.INNER);
-        Join<UserEntity, TenantSpecialtyEntity> specialtyJoin = tenantJoin.join("tenantSpecialty", JoinType.LEFT);
+        Join<UserEntity, TenantSpecialtyEntity> specialtyJoin =
+                tenantJoin.join("tenantSpecialty", JoinType.LEFT);
 
         // Add predicate to filter only accepted requests
         Predicate acceptedStatus = cb.equal(root.get("status"), RentRequest.Status.ACCEPTED);
         cq.select(root).distinct(true).where(acceptedStatus);
-        
+
         List<RentRequestEntity> entities = entityManager.createQuery(cq).getResultList();
 
-        return entities.stream()
-            .map(entity -> {
-                GetRentRequestSpecialistsDashboardDTO dto = new GetRentRequestSpecialistsDashboardDTO();
-                dto.setRentRequestId(entity.getId());
-                dto.setTenantName(entity.getTenant().getFullName());
-                dto.setClinicName(entity.getClinic().getDisplayName());
-                dto.setStatus(entity.getStatus());
-                dto.setCreatedAt(entity.getCreatedAt());
-                
-                // Set tenant specialty
-                if (entity.getTenant().getTenantSpecialty() != null) {
-                    dto.setTenantSpecialty(entity.getTenant().getTenantSpecialty().getName());
-                }
-                
-                // Set clinic location information
-                dto.setClinicAddress(entity.getClinic().getAddressStreet() + ", " + 
-                                   entity.getClinic().getAddressCity());
-                dto.setClinicBorough(entity.getClinic().getAddressCity()); // Assuming city is the borough
-                dto.setClinicLatitude(Double.parseDouble(entity.getClinic().getAddressLatitude()));
-                dto.setClinicLongitude(Double.parseDouble(entity.getClinic().getAddressLongitude()));
-                
-                return dto;
-            })
-            .collect(Collectors.toList());
+        return entities.stream().map(entity -> {
+            GetRentRequestSpecialistsDashboardDTO dto = new GetRentRequestSpecialistsDashboardDTO();
+            dto.setRentRequestId(entity.getId());
+            dto.setTenantName(entity.getTenant().getFullName());
+            dto.setClinicName(entity.getClinic().getDisplayName());
+            dto.setStatus(entity.getStatus());
+            dto.setCreatedAt(entity.getCreatedAt());
+
+            // Set tenant specialty
+            if (entity.getTenant().getTenantSpecialty() != null) {
+                dto.setTenantSpecialty(entity.getTenant().getTenantSpecialty().getName());
+            }
+
+            // Set clinic location information
+            dto.setClinicAddress(entity.getClinic().getAddressStreet() + ", "
+                    + entity.getClinic().getAddressCity());
+            dto.setClinicBorough(entity.getClinic().getAddressCity()); // Assuming city is the
+                                                                       // borough
+            dto.setClinicLatitude(Double.parseDouble(entity.getClinic().getAddressLatitude()));
+            dto.setClinicLongitude(Double.parseDouble(entity.getClinic().getAddressLongitude()));
+
+            return dto;
+        }).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/medspace/infrastructure/rest/RentRequestController.java
+++ b/src/main/java/com/medspace/infrastructure/rest/RentRequestController.java
@@ -74,7 +74,7 @@ public class RentRequestController {
     @GET
     @Path("/my-requests")
     @UserOnly
-    public Response getRequestsByUser(@QueryParam("status") String targetStatus) {
+    public Response getRequestsByUser(@QueryParam("status") RentRequest.Status targetStatus) {
         User loggedInUser = requestContext.getUser();
         RentRequestQueryFilterDTO filterDTO = new RentRequestQueryFilterDTO(loggedInUser.getId());
         if (targetStatus != null) {


### PR DESCRIPTION
## Summary
This PR changes the ReviewRepositoryImpl and the RentRequestRepositoryImpl, so that the complex queries are changed to use the ORM functionality.

## Test Plan
Manually tested endpoints to show they have the same behavior as before

GET /users/{id}/public-profile
<img width="1014" alt="Captura de pantalla 2025-05-19 a la(s) 1 52 24 p m" src="https://github.com/user-attachments/assets/cde5bf41-4f1c-4ba9-9f53-a6b19cfbe281" />

GET /clinics
<img width="1037" alt="Captura de pantalla 2025-05-19 a la(s) 1 52 47 p m" src="https://github.com/user-attachments/assets/5a4b9cc7-1e76-4a8e-a8b8-da3356847825" />
