### PR TITLE
Added filters for ladlord cards

### DIFF
--- a/src/main/java/com/medspace/application/service/ClinicService.java
+++ b/src/main/java/com/medspace/application/service/ClinicService.java
@@ -13,6 +13,7 @@ import com.medspace.domain.repository.ReviewRepository;
 import com.medspace.infrastructure.dto.clinic.ClinicQueryDTO;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.Set;
 
 import java.time.Instant;
 import java.util.List;
@@ -199,6 +200,15 @@ public class ClinicService {
 
     public long countClinicsByCategory(Clinic.Category category) {
         return clinicRepository.countClinicsByCategory(category);
+    }
+    public long countByCity(String city) {
+        return clinicRepository.countByCity(city);
+    }    
+    public Set<String> findAllUniqueCities() {
+        return clinicRepository.findAllUniqueCities();
+    }
+    public long getByCategoryAndCity(Clinic.Category category, String city){
+        return clinicRepository.getByCategoryAndCity(category, city);
     }
     
 }

--- a/src/main/java/com/medspace/application/usecase/clinic/GetAllCitiesWithClinicsUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinic/GetAllCitiesWithClinicsUseCase.java
@@ -1,0 +1,17 @@
+package com.medspace.application.usecase.clinic;
+import java.util.Set;
+import com.medspace.application.service.ClinicService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+
+public class GetAllCitiesWithClinicsUseCase {
+    @Inject
+    ClinicService clinicService;
+     
+    public Set<String> execute(){
+        return clinicService.findAllUniqueCities() ;
+    }
+    
+}

--- a/src/main/java/com/medspace/application/usecase/clinic/GetClinicCountByCityUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinic/GetClinicCountByCityUseCase.java
@@ -1,0 +1,16 @@
+package com.medspace.application.usecase.clinic;
+
+import com.medspace.application.service.ClinicService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class GetClinicCountByCityUseCase {
+
+    @Inject
+    ClinicService clinicService;
+
+    public long execute(String city) {
+        return clinicService.countByCity(city);
+    }
+}

--- a/src/main/java/com/medspace/application/usecase/clinic/GetClinicsByCategoryAndCityUseCase.java
+++ b/src/main/java/com/medspace/application/usecase/clinic/GetClinicsByCategoryAndCityUseCase.java
@@ -1,0 +1,18 @@
+package com.medspace.application.usecase.clinic;
+
+import com.medspace.application.service.ClinicService;
+import com.medspace.domain.model.Clinic;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+
+@ApplicationScoped
+public class GetClinicsByCategoryAndCityUseCase {
+    @Inject
+    ClinicService clinicService;
+    
+    public  long execute (Clinic.Category category, String city){
+        return clinicService.getByCategoryAndCity(category, city);
+    }
+
+}

--- a/src/main/java/com/medspace/domain/repository/ClinicRepository.java
+++ b/src/main/java/com/medspace/domain/repository/ClinicRepository.java
@@ -3,6 +3,7 @@ package com.medspace.domain.repository;
 import com.medspace.domain.model.Clinic;
 import com.medspace.infrastructure.dto.clinic.ClinicQueryDTO;
 import java.util.List;
+import java.util.Set;
 
 public interface ClinicRepository {
     public Clinic insertClinic(Clinic clinic);
@@ -25,4 +26,9 @@ public interface ClinicRepository {
 
     long countClinicsByCategory(Clinic.Category category);
 
+    long countByCity(String city);
+
+    Set<String> findAllUniqueCities();
+    
+    long getByCategoryAndCity(Clinic.Category category, String city);
 }

--- a/src/main/java/com/medspace/infrastructure/dto/clinic/CityFilterDTO.java
+++ b/src/main/java/com/medspace/infrastructure/dto/clinic/CityFilterDTO.java
@@ -1,0 +1,19 @@
+package com.medspace.infrastructure.dto.clinic;
+
+import java.sql.Date;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class CityFilterDTO {
+    public String label; 
+    public String value; 
+}


### PR DESCRIPTION


### **Pull Request: Add Filter Endpoints for Clinics by City and Category**

#### **Description**

This PR introduces multiple new features and backend endpoints to support clinic filtering by **city**, **category**, or both. These changes enable the frontend to dynamically fetch and display clinic metrics based on user-selected filters.

#### **Key Additions**

✅ **New Use Cases:**

* `GetClinicCountByCityUseCase`: Returns the count of clinics in a given city.
* `GetClinicsByCategoryAndCityUseCase`: Returns the count of clinics by both category and city.
* `GetAllCitiesWithClinicsUseCase`: Fetches all distinct city names from existing clinics.

✅ **DTO:**

* `CityFilterDTO`: Simple DTO used to return cities as `{ label, value }` objects for dropdowns or filters in the frontend.

✅ **ClinicRepository Interface & Implementation:**

* `countByCity(city: String)`
* `getByCategoryAndCity(category: Clinic.Category, city: String)`
* `findAllUniqueCities()`

✅ **New REST Endpoints in `ClinicController`:**

* `GET /clinics/city-clinics/{city}`: Get clinic count by city.
* `GET /clinics/filter?category={category}&city={city}`: Get clinic count filtered by both city and category.
* `GET /clinics/cities`: Get a list of all unique clinic cities.

All endpoints handle input normalization to ensure reliable filtering (e.g., lowercase, remove accents, replace spaces with underscores).

#### **Reasoning**

These changes are foundational for enabling client-side filtering on the main page. With these endpoints in place, the frontend can:

* Fetch the total number of clinics.
* Dynamically adjust counts based on filter selection.
* Populate filter dropdowns with valid city options.

#### **Testing**

* ✅ Manually tested city normalization and counts for cities with spaces and accents.
* ✅ Validated correct results for combinations of category + city.
* ✅ Ensured appropriate error responses for invalid or missing parameters.

---
<img width="1086" alt="Screenshot 2025-06-08 at 9 26 16 p m" src="https://github.com/user-attachments/assets/81119147-f7ea-489a-961b-55d8e6e2b1b7" />
<img width="1077" alt="Screenshot 2025-06-08 at 9 26 24 p m" src="https://github.com/user-attachments/assets/eb4b9d85-d08c-4761-9f1f-2fa949e9e629" />

<img width="1091" alt="Screenshot 2025-06-08 at 9 26 01 p m" src="https://github.com/user-attachments/assets/241253f0-9ba6-4c43-9163-82f86aba9da4" />
