### PR TITLE
Added external clinic service test

### DIFF
--- a/src/main/java/com/medspace/application/service/ExternalClinicServiceTest.java
+++ b/src/main/java/com/medspace/application/service/ExternalClinicServiceTest.java
@@ -1,0 +1,61 @@
+package com.medspace.application.service;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.medspace.domain.model.ExternalClinic;
+import com.medspace.domain.repository.ExternalClinicRepository;
+import com.medspace.infrastructure.client.ExternalClinicApiClient;
+import com.medspace.infrastructure.dto.common.PaginationDTO;
+import com.medspace.infrastructure.dto.externalClinic.GetExternalClinicSpecialistsDashboardDTO;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import java.util.*;
+
+@QuarkusTest
+class ExternalClinicServiceTest {
+    @InjectMock
+    ExternalClinicRepository repository;
+
+    @InjectMock
+    ExternalClinicApiClient apiClient;
+
+    @Inject
+    ExternalClinicService service;
+
+    @Test
+    void testGetDashboardDataWithPagination() {
+        PaginationDTO pagination = new PaginationDTO(0, 10);
+        List<GetExternalClinicSpecialistsDashboardDTO> mockList = List.of();
+        when(repository.getExternalClinicSpecialistsDashboardData(pagination)).thenReturn(mockList);
+        List<GetExternalClinicSpecialistsDashboardDTO> result =
+                service.getDashboardDataWithPagination(pagination);
+        assertNotNull(result);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void testGetDashboardDataAll() {
+        List<GetExternalClinicSpecialistsDashboardDTO> mockList = List.of();
+        when(repository.getAllExternalClinicSpecialistsDashboardData()).thenReturn(mockList);
+        List<GetExternalClinicSpecialistsDashboardDTO> result = service.getDashboardDataAll();
+        assertNotNull(result);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void testFetchAndSaveClinics() {
+        List<ExternalClinic> clinics = new ArrayList<>();
+        when(apiClient.fetchClinics()).thenReturn(clinics);
+        service.fetchAndSaveClinics();
+        verify(repository).saveAll(clinics);
+    }
+
+    @Test
+    void testUpdateSpecialties() {
+        service.updateSpecialties();
+        verify(repository).updateSpecialties();
+    }
+}

--- a/src/main/java/com/medspace/infrastructure/ExternalClinicRestTest.java
+++ b/src/main/java/com/medspace/infrastructure/ExternalClinicRestTest.java
@@ -1,0 +1,17 @@
+package com.medspace.infrastructure;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class ExternalClinicRestTest {
+
+
+    @Test
+    void testGetDashboardData() {
+        given().when().get("/api/external-clinics/dashboard").then().statusCode(200).body("success",
+                is(true));
+    }
+}


### PR DESCRIPTION

---

###  **PR Summary: Unit Tests for `ExternalClinicService`**

This PR adds unit tests for the `ExternalClinicService` class using JUnit 5 and Quarkus testing framework with Mockito for mocking dependencies.

####  **Tests Included:**

1. **`testGetDashboardDataWithPagination`**

   * Verifies that the service correctly fetches paginated dashboard data from the repository.
   * Asserts the result is not null and matches the expected size (empty list in this test case).

2. **`testGetDashboardDataAll`**

   * Verifies that the service retrieves all dashboard data without pagination.
   * Checks that the returned list is empty and not null.

3. **`testFetchAndSaveClinics`**

   * Ensures the service fetches clinics via the API client and saves them using the repository.
   * Confirms `saveAll` is called with the fetched list.

4. **`testUpdateSpecialties`**

   * Verifies that the service delegates the specialty update logic to the repository.

####  **Tools Used:**

* **Mockito** for mocking `ExternalClinicRepository` and `ExternalClinicApiClient`.
* **QuarkusTest** for dependency injection in tests.
* **JUnit 5** for assertions and test structure.

